### PR TITLE
Fix silently-broken scraper (Cloudflare) + fail loud

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -24,21 +24,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
+    # 2kratings.com is behind Cloudflare's JS challenge, which blocks HEADLESS
+    # Chrome (HTTP 403). We run the browser HEADED under a virtual display
+    # (xvfb) so the challenge is solved like a real browser. Headless runs
+    # silently scraped 0 players for weeks while reporting success — the
+    # scraper now also exits non-zero on a 0-player run so this can't regress
+    # quietly again.
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright Chromium
-        run: npx playwright install chromium
+      # --with-deps installs the OS libraries Chromium needs; xvfb provides the
+      # virtual display that lets us run headed in a headless CI environment.
+      - name: Install Playwright Chromium + system deps
+        run: |
+          npx playwright install --with-deps chromium
+          sudo apt-get update && sudo apt-get install -y xvfb
 
       - name: Generate Convex client
         env:
@@ -50,21 +60,21 @@ jobs:
         env:
           CONVEX_URL: ${{ secrets.CONVEX_URL }}
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
-        run: node scripts/runScraper.js curr
+        run: xvfb-run -a node scripts/runScraper.js curr
 
       - name: Run scraper (classic teams)
         if: github.event.inputs.team_type == 'class'
         env:
           CONVEX_URL: ${{ secrets.CONVEX_URL }}
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
-        run: node scripts/runScraper.js class
+        run: xvfb-run -a node scripts/runScraper.js class
 
       - name: Run scraper (all-time teams)
         if: github.event.inputs.team_type == 'allt'
         env:
           CONVEX_URL: ${{ secrets.CONVEX_URL }}
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
-        run: node scripts/runScraper.js allt
+        run: xvfb-run -a node scripts/runScraper.js allt
 
       - name: Run scraper (all team types)
         if: github.event.inputs.team_type == 'all'
@@ -72,6 +82,6 @@ jobs:
           CONVEX_URL: ${{ secrets.CONVEX_URL }}
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
         run: |
-          node scripts/runScraper.js curr
-          node scripts/runScraper.js class
-          node scripts/runScraper.js allt
+          xvfb-run -a node scripts/runScraper.js curr
+          xvfb-run -a node scripts/runScraper.js class
+          xvfb-run -a node scripts/runScraper.js allt

--- a/README.md
+++ b/README.md
@@ -525,7 +525,8 @@ MIT License - see LICENSE file for details
 
 ## Analytics
 
-**Baseline (Nov 2025 - Feb 2026):** 48 API keys created, 1,842 requests made.
+**Feb 2026 baseline:** 48 API keys, 1,842 requests.
+**Jun 2026:** 168 API keys (146 active), ~45,700 requests — ~25× request growth in four months.
 
 ## Disclaimer
 

--- a/scraper/config.js
+++ b/scraper/config.js
@@ -133,8 +133,11 @@ export const PLAYER_SELECTORS = {
  * Scraping options
  */
 export const SCRAPER_OPTIONS = {
-  // Browser options - headless in CI, headed locally for bot detection avoidance
-  headless: process.env.CI === 'true' || process.env.HEADLESS === 'true',
+  // Browser options.
+  // Cloudflare blocks headless Chrome on 2kratings.com, so we run HEADED by
+  // default — locally with a real display, in CI under a virtual one (xvfb).
+  // Only go headless when explicitly forced (HEADLESS=true), e.g. for debugging.
+  headless: process.env.HEADLESS === 'true',
 
   // Navigation options
   waitUntil: 'domcontentloaded',

--- a/scraper/utils.js
+++ b/scraper/utils.js
@@ -6,23 +6,57 @@ import { chromium } from 'playwright';
 import { SCRAPER_OPTIONS, BASE_URL } from './config.js';
 
 /**
- * Initialize and launch browser
+ * Initialize and launch browser.
+ *
+ * 2kratings.com sits behind Cloudflare's "Just a moment..." JS challenge.
+ * A real (headed) browser solves it automatically; a headless browser gets
+ * blocked (HTTP 403). In CI we therefore run headed under a virtual display
+ * (xvfb) — see .github/workflows/scrape.yml. The launch args below strip the
+ * most obvious automation fingerprints so the challenge passes cleanly.
+ *
  * @returns {Promise<Browser>} Playwright browser instance
  */
 export async function initBrowser() {
   const browser = await chromium.launch({
-    headless: SCRAPER_OPTIONS.headless
+    headless: SCRAPER_OPTIONS.headless,
+    args: [
+      '--disable-blink-features=AutomationControlled',
+      '--no-sandbox',
+      '--disable-dev-shm-usage',
+      '--disable-features=IsolateOrigins,site-per-process',
+    ],
   });
   return browser;
 }
 
+const STEALTH_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36';
+
 /**
- * Create a new page with default settings
+ * Create a new page inside a hardened browser context.
+ *
+ * Sets a realistic user agent / viewport / locale and removes the
+ * `navigator.webdriver` flag so Cloudflare's bot-detection treats the session
+ * as an ordinary browser. Use this everywhere instead of `browser.newPage()`.
+ *
  * @param {Browser} browser - Playwright browser instance
  * @returns {Promise<Page>} Playwright page instance
  */
 export async function createPage(browser) {
-  const page = await browser.newPage();
+  const context = await browser.newContext({
+    userAgent: STEALTH_USER_AGENT,
+    viewport: { width: 1280, height: 800 },
+    locale: 'en-US',
+    timezoneId: 'America/Chicago',
+  });
+
+  // Hide the headless/automation tell that Cloudflare checks for.
+  await context.addInitScript(() => {
+    Object.defineProperty(navigator, 'webdriver', { get: () => undefined });
+  });
+
+  const page = await context.newPage();
 
   // Set default timeout
   page.setDefaultTimeout(SCRAPER_OPTIONS.timeout);

--- a/scripts/runScraper.js
+++ b/scripts/runScraper.js
@@ -7,7 +7,7 @@ import { ConvexHttpClient } from "convex/browser";
 import { api } from "../convex/_generated/api.js";
 import { scrapeTeamLinks, scrapeTeamRoster } from '../scraper/teamScraper.js';
 import { scrapePlayerDetails } from '../scraper/playerScraper.js';
-import { initBrowser } from '../scraper/utils.js';
+import { initBrowser, createPage } from '../scraper/utils.js';
 
 // IMPORTANT: Scraper uses ConvexHttpClient which requires .convex.cloud domain
 // (NOT .convex.site which is for HTTP actions)
@@ -44,7 +44,7 @@ async function runScraper(options = {}) {
   try {
     // Initialize browser
     const browser = await initBrowser();
-    const page = await browser.newPage();
+    const page = await createPage(browser);
 
     try {
       // Scrape team links
@@ -197,6 +197,19 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   runScraper({ teamType, teams })
     .then(result => {
       console.log('\nScraper result:', JSON.stringify(result, null, 2));
+
+      // Fail loudly on an empty scrape. `success` only reflects "no exception
+      // thrown" — but a Cloudflare block returns 0 teams/players WITHOUT
+      // throwing, so the old code exited 0 and CI stayed green on frozen data
+      // for weeks. A 0-player run is a real failure: surface it so CI goes red.
+      if (result.playersScraped === 0) {
+        console.error(
+          '\n✖ FAILURE: scraped 0 players. The source almost certainly blocked ' +
+          'the browser (Cloudflare). Data was NOT updated — failing so CI alerts.'
+        );
+        process.exit(1);
+      }
+
       process.exit(result.success ? 0 : 1);
     })
     .catch(error => {


### PR DESCRIPTION
## Problem
The scheduled roster scrape silently broke around **May 19**. 2kratings.com is behind Cloudflare's "Just a moment…" JS challenge, which returns **403 to headless Chrome**. The scraper caught nothing, returned \`success: true\` with **0 players**, and exited **0** — so CI stayed green while prod player data froze for ~40 days. The June 1 & 15 runs each "succeeded" in ~50s, scraping 0 teams.

Blacktop Blitz, which syncs daily from this API, was therefore serving the same frozen data.

## Fix (sustainable, no new paid services)
- **Run headed by default**; CI runs headed under a virtual display (**xvfb**). A real browser solves the Cloudflare challenge — verified locally: 30 teams / full rosters in seconds, vs 403 for headless.
- **Harden the browser context** — realistic UA/viewport/locale, strip \`navigator.webdriver\`, \`AutomationControlled\` off.
- **Fail loud**: a 0-player scrape now exits non-zero so CI goes red instead of freezing data silently.
- CI: \`xvfb-run\`, \`playwright install --with-deps chromium\`, bump checkout/setup-node → v5 / Node 22.
- Docs: refresh stale analytics line (48 keys/1.8k req → 168 keys/~45.7k req).

## Verification
- Local headed scrape repopulated prod current-team rosters end-to-end.
- New hardened \`createPage\` path confirmed: 30 teams, \`navigator.webdriver\` hidden, UA spoofed.
- Triggered this workflow on the branch to confirm xvfb+headed passes Cloudflare from a GitHub runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)