### PR TITLE
feat: render badge icons on player pages + de-dupe badge list

### DIFF
--- a/components/player/badges-grid.tsx
+++ b/components/player/badges-grid.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import Image from "next/image";
 import { motion } from "framer-motion";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -49,15 +50,19 @@ type BadgeTier = keyof typeof TIER_COLORS;
 /**
  * Group badges by category (prevents duplication by only using badges.list)
  */
+type OrganizedBadge = { name: string; tier: string; imageUrl?: string };
+
 function organizeBadges(badges: PlayerBadges) {
-  const organized: Record<string, Array<{ name: string; tier: string }>> = {};
-  const seenBadges = new Set<string>(); // Track unique badge names to prevent duplicates
+  const organized: Record<string, Array<OrganizedBadge>> = {};
+  const seenBadges = new Set<string>(); // Track unique badge name+tier to prevent duplicates
 
   // Only use the list property to prevent duplication
   if (badges.list && Array.isArray(badges.list)) {
     badges.list.forEach((badge) => {
-      // Skip if we've already seen this exact badge name (case-insensitive)
-      const badgeKey = badge.name.toLowerCase().trim();
+      // Skip if we've already seen this exact badge name+tier (case-insensitive).
+      // The scraper can emit each badge twice (2kratings renders a desktop +
+      // mobile card for the same badge), so de-dupe on name+tier here.
+      const badgeKey = `${badge.name.toLowerCase().trim()}|${badge.tier.toLowerCase().trim()}`;
       if (seenBadges.has(badgeKey)) {
         return; // Skip duplicate
       }
@@ -70,6 +75,7 @@ function organizeBadges(badges: PlayerBadges) {
       organized[category].push({
         name: badge.name,
         tier: badge.tier,
+        imageUrl: badge.imageUrl,
       });
     });
   }
@@ -114,7 +120,7 @@ export function BadgesGrid({ player, className }: BadgesGridProps) {
   const filteredBadges = React.useMemo(() => {
     if (selectedTier === "All") return organizedBadges;
 
-    const filtered: Record<string, Array<{ name: string; tier: string }>> = {};
+    const filtered: Record<string, Array<OrganizedBadge>> = {};
     Object.entries(organizedBadges).forEach(([category, badgesList]) => {
       const tierBadges = badgesList.filter((b) => {
         // Case-insensitive comparison and handle variations
@@ -245,14 +251,24 @@ export function BadgesGrid({ player, className }: BadgesGridProps) {
                           <Badge
                             variant="outline"
                             className={cn(
-                              "border transition-all duration-150 hover:scale-105",
+                              "gap-1.5 border transition-all duration-150 hover:scale-105",
                               tierColors.bg,
                               tierColors.text,
                               tierColors.border
                             )}
                           >
+                            {badge.imageUrl ? (
+                              <Image
+                                src={badge.imageUrl}
+                                alt={`${badge.name} ${badge.tier} badge`}
+                                width={20}
+                                height={20}
+                                className="h-5 w-5 shrink-0 object-contain"
+                                unoptimized
+                              />
+                            ) : null}
                             <span className="font-semibold">{badge.name}</span>
-                            <span className="ml-1.5 opacity-70">· {badge.tier}</span>
+                            <span className="ml-1 opacity-70">· {badge.tier}</span>
                           </Badge>
                         </motion.div>
                       );

--- a/scraper/playerScraper.js
+++ b/scraper/playerScraper.js
@@ -170,8 +170,12 @@ export async function scrapePlayerDetails(page, basicPlayer) {
         else if (title.includes('Bronze')) badges.bronze = value;
       });
 
-      // Extract individual badge details with image URLs
+      // Extract individual badge details with image URLs.
+      // 2kratings renders each badge card twice (desktop + mobile layouts share
+      // the same .badge-card class), so de-dupe on name+tier to avoid storing
+      // every badge twice.
       const badgeList = [];
+      const seenBadgeKeys = new Set();
       const badgeCards = document.querySelectorAll('.badge-card');
 
       for (const card of badgeCards) {
@@ -195,6 +199,12 @@ export async function scrapePlayerDetails(page, basicPlayer) {
           else if (imgSrc.includes('-bronze-badge.png')) tier = 'Bronze';
 
           if (name && tier) {
+            const badgeKey = `${name.toLowerCase().trim()}|${tier.toLowerCase().trim()}`;
+            if (seenBadgeKeys.has(badgeKey)) {
+              continue; // Skip duplicate card (desktop/mobile render the same badge)
+            }
+            seenBadgeKeys.add(badgeKey);
+
             const badgeData = { name, tier, category };
             // Include image URL if it's a full URL (not relative)
             if (imgSrc.startsWith('http')) {

--- a/types/player.ts
+++ b/types/player.ts
@@ -58,6 +58,8 @@ export interface Badge {
   name: string;
   tier: string;
   category?: string;
+  description?: string;
+  imageUrl?: string;
 }
 
 export interface PlayerBadges {


### PR DESCRIPTION
Re-opened against `main` (original #6 was stacked on the scraper-fix branch and auto-closed when that merged). Rebased to badge-only changes.

- Render scraped badge icon images (`badges.list[].imageUrl`) on player pages instead of text-only.
- De-dupe the badge list by `name+tier` in **both** the scraper (root-cause fix for the double-matching `.badge-card` selector) and the component (protects existing prod docs until re-scraped) — fixes the 40-shown-vs-20-counted discrepancy.

Independently reviewed: verdict **MERGE AS-IS** (de-dupe key correct, dual-layer justified, type flow clean, no regression to tier filters/counts). Minor follow-ups noted (decorative alt text, onError fallback for broken badge URLs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)