### PR TITLE
fix: badge icons 403 in prod (route through Next image optimizer)

### DIFF
--- a/components/player/badges-grid.tsx
+++ b/components/player/badges-grid.tsx
@@ -258,13 +258,19 @@ export function BadgesGrid({ player, className }: BadgesGridProps) {
                             )}
                           >
                             {badge.imageUrl ? (
+                              // NOT `unoptimized`: 2kratings hot-link-protects its
+                              // images against third-party referers, so a direct
+                              // browser fetch 403s (badges rendered as broken icons
+                              // in prod). Routing through Next's image optimizer —
+                              // same as the player photo — proxies the fetch
+                              // server-side (no browser referer) so it loads. The
+                              // 2kratings host is allowlisted in next.config.ts.
                               <Image
                                 src={badge.imageUrl}
                                 alt={`${badge.name} ${badge.tier} badge`}
                                 width={20}
                                 height={20}
                                 className="h-5 w-5 shrink-0 object-contain"
-                                unoptimized
                               />
                             ) : null}
                             <span className="font-semibold">{badge.name}</span>


### PR DESCRIPTION
## Problem
After the badge-images feature shipped, **every badge icon is broken in production** (verified live on a player page: 20/20 images `naturalWidth: 0`). The badge `<Image>` used `unoptimized`, so the browser fetched `2kratings.com/...png` directly with a third-party `Referer` — which 2kratings hot-link-blocks with a 403.

## Why the player photo works but badges didn't
The player photo `<Image>` is NOT `unoptimized`, so it goes through Next's image optimizer, which fetches server-side (no browser `Referer`) and serves the image same-origin from `/_next/image`. The badges bypassed that.

## Fix
Remove `unoptimized` from the badge `<Image>` so it uses the same optimizer path. The 2kratings host is already in `next.config.ts` `remotePatterns`.

## Verified (mechanism, deterministic)
```
GET deadeye-hof-badge.png  Referer: nba2kapi.com  -> HTTP 403   (current broken path)
GET deadeye-hof-badge.png  (no Referer)            -> HTTP 200   (optimizer path)
```
Will confirm on prod after deploy (badge images load, naturalWidth > 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)