### PR TITLE
ci: scrape automation safety + reliability (dry-run, retries, partial-fail, Convex deploy)

### DIFF
--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy Convex (prod)
+
+# The Vercel build runs `convex codegen` but NOT `convex deploy`, so the prod
+# Convex deployment only updated when someone ran `npx convex deploy` by hand —
+# easy to forget, and a drift between merged code and live functions/schema is
+# how the scraper's admin-key/schema expectations broke before. This deploys
+# Convex to prod automatically whenever convex/ changes land on main, using the
+# existing CONVEX_DEPLOY_KEY secret. It's isolated from the Vercel build, so a
+# failed deploy here can't take down the website.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'convex/**'
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch: # manual trigger to verify / force a deploy
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Deploy to Convex prod
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: npx convex deploy -y

--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -17,9 +17,15 @@ on:
       - 'package-lock.json'
   workflow_dispatch: # manual trigger to verify / force a deploy
 
+# Serialize deploys so two quick merges can't race a last-write-wins push.
+concurrency:
+  group: convex-deploy-prod
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -18,6 +18,11 @@ on:
           - class
           - allt
           - all
+      reconcile_dry_run:
+        description: 'Reconcile in DRY-RUN (report departed/orphan players, delete nothing)'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   scrape:
@@ -60,6 +65,8 @@ jobs:
         env:
           CONVEX_URL: ${{ secrets.CONVEX_URL }}
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
+          # Scheduled runs always reconcile for real; manual dispatch can preview.
+          RECONCILE_DRY_RUN: ${{ github.event.inputs.reconcile_dry_run || 'false' }}
         run: xvfb-run -a node scripts/runScraper.js curr
 
       - name: Run scraper (classic teams)
@@ -67,6 +74,8 @@ jobs:
         env:
           CONVEX_URL: ${{ secrets.CONVEX_URL }}
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
+          # Scheduled runs always reconcile for real; manual dispatch can preview.
+          RECONCILE_DRY_RUN: ${{ github.event.inputs.reconcile_dry_run || 'false' }}
         run: xvfb-run -a node scripts/runScraper.js class
 
       - name: Run scraper (all-time teams)
@@ -74,6 +83,8 @@ jobs:
         env:
           CONVEX_URL: ${{ secrets.CONVEX_URL }}
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
+          # Scheduled runs always reconcile for real; manual dispatch can preview.
+          RECONCILE_DRY_RUN: ${{ github.event.inputs.reconcile_dry_run || 'false' }}
         run: xvfb-run -a node scripts/runScraper.js allt
 
       - name: Run scraper (all team types)
@@ -81,6 +92,8 @@ jobs:
         env:
           CONVEX_URL: ${{ secrets.CONVEX_URL }}
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
+          # Scheduled runs always reconcile for real; manual dispatch can preview.
+          RECONCILE_DRY_RUN: ${{ github.event.inputs.reconcile_dry_run || 'false' }}
         run: |
           xvfb-run -a node scripts/runScraper.js curr
           xvfb-run -a node scripts/runScraper.js class

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -67,7 +67,7 @@ jobs:
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
           # Scheduled runs always reconcile for real; manual dispatch can preview.
           RECONCILE_DRY_RUN: ${{ github.event.inputs.reconcile_dry_run || 'false' }}
-        run: xvfb-run -a node scripts/runScraper.js curr
+        run: bash scripts/scrape-retry.sh curr
 
       - name: Run scraper (classic teams)
         if: github.event.inputs.team_type == 'class'
@@ -76,7 +76,7 @@ jobs:
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
           # Scheduled runs always reconcile for real; manual dispatch can preview.
           RECONCILE_DRY_RUN: ${{ github.event.inputs.reconcile_dry_run || 'false' }}
-        run: xvfb-run -a node scripts/runScraper.js class
+        run: bash scripts/scrape-retry.sh class
 
       - name: Run scraper (all-time teams)
         if: github.event.inputs.team_type == 'allt'
@@ -85,7 +85,7 @@ jobs:
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
           # Scheduled runs always reconcile for real; manual dispatch can preview.
           RECONCILE_DRY_RUN: ${{ github.event.inputs.reconcile_dry_run || 'false' }}
-        run: xvfb-run -a node scripts/runScraper.js allt
+        run: bash scripts/scrape-retry.sh allt
 
       - name: Run scraper (all team types)
         if: github.event.inputs.team_type == 'all'
@@ -95,6 +95,6 @@ jobs:
           # Scheduled runs always reconcile for real; manual dispatch can preview.
           RECONCILE_DRY_RUN: ${{ github.event.inputs.reconcile_dry_run || 'false' }}
         run: |
-          xvfb-run -a node scripts/runScraper.js curr
-          xvfb-run -a node scripts/runScraper.js class
-          xvfb-run -a node scripts/runScraper.js allt
+          bash scripts/scrape-retry.sh curr
+          bash scripts/scrape-retry.sh class
+          bash scripts/scrape-retry.sh allt

--- a/scripts/runScraper.js
+++ b/scripts/runScraper.js
@@ -190,6 +190,7 @@ async function runScraper(options = {}) {
       playersAdded,
       playersUnchanged,
       teamsScraped,
+      emptyTeams,
       errors,
       duration,
       startTime,
@@ -211,6 +212,7 @@ async function runScraper(options = {}) {
       playersAdded,
       playersUnchanged,
       teamsScraped,
+      emptyTeams,
       errors: [...errors, error.message],
       duration,
       startTime,
@@ -237,6 +239,22 @@ if (import.meta.url === `file://${process.argv[1]}`) {
         console.error(
           '\n✖ FAILURE: scraped 0 players. The source almost certainly blocked ' +
           'the browser (Cloudflare). Data was NOT updated — failing so CI alerts.'
+        );
+        process.exit(1);
+      }
+
+      // Fail loudly on a PARTIAL scrape too. Cloudflare often soft-blocks part
+      // way through a session: some teams return rosters, others come back with
+      // 0 players (no error thrown). Every real NBA/2K team has a roster, so any
+      // empty team means the scrape is incomplete and most of the data went
+      // stale — which previously still exited 0 (green) because >0 players were
+      // scraped. Treat it as a failure so CI alerts and the run can be retried.
+      // (Reconcile already self-protects by skipping when emptyTeams > 0.)
+      if (result.emptyTeams > 0) {
+        console.error(
+          `\n✖ FAILURE: ${result.emptyTeams} team(s) returned 0 players (partial ` +
+          `Cloudflare block). Only ${result.playersScraped} players scraped — the ` +
+          'rest are stale. Failing so CI alerts; rerun to get a complete scrape.'
         );
         process.exit(1);
       }

--- a/scripts/scrape-retry.sh
+++ b/scripts/scrape-retry.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Retry a single-teamType scrape up to N times.
+#
+# CI runs from a GitHub datacenter IP that Cloudflare blocks *flakily* — across
+# back-to-back runs we've seen a full scrape (all teams), a partial block (some
+# teams return 0 players), and a total block (0 players). Each attempt is an
+# independent browser session that re-solves the challenge, so retrying turns a
+# ~50%-per-attempt success rate into a high-probability clean run per job.
+#
+# runScraper.js exits non-zero on a 0-player OR partial scrape (any empty team),
+# so a non-zero exit here means "incomplete — try again". A clean full scrape
+# exits 0 and we stop. Inherits CONVEX_URL / ADMIN_API_KEY / RECONCILE_DRY_RUN
+# from the environment.
+set -u
+
+TEAM_TYPE="${1:?usage: scrape-retry.sh <curr|class|allt>}"
+MAX_ATTEMPTS="${SCRAPE_MAX_ATTEMPTS:-3}"
+BACKOFF_SECONDS="${SCRAPE_RETRY_BACKOFF:-30}"
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  if xvfb-run -a node scripts/runScraper.js "$TEAM_TYPE"; then
+    echo "scrape($TEAM_TYPE) succeeded on attempt $attempt/$MAX_ATTEMPTS"
+    exit 0
+  fi
+  if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+    echo "::warning::scrape($TEAM_TYPE) attempt $attempt/$MAX_ATTEMPTS was blocked/partial; retrying in ${BACKOFF_SECONDS}s"
+    sleep "$BACKOFF_SECONDS"
+  fi
+done
+
+echo "::error::scrape($TEAM_TYPE) failed after $MAX_ATTEMPTS attempts (Cloudflare). Data not (fully) updated."
+exit 1


### PR DESCRIPTION
Hardens the scrape/reconcile automation after the post-mortem. Four changes, all validated in CI today.

### 1. Reconcile dry-run input
`workflow_dispatch` gains a `reconcile_dry_run` boolean so the full scrape→reconcile path can be previewed (report orphans, delete nothing) before the scheduled cron prunes for real. Scheduled runs default to real reconcile.

### 2. Fail loud on PARTIAL scrapes
A CI run revealed Cloudflare can soft-block *part way* through (73 players from 4 teams; 26 teams returned 0) yet still exit 0 (green), silently leaving most rosters stale. `runScraper` now exits non-zero when `emptyTeams > 0`. (The reconcile guard already independently skips pruning in that case — verified: a 26-empty-team run correctly SKIPPED instead of deleting ~459 players.)

### 3. Retry wrapper (3× per teamType)
`scripts/scrape-retry.sh` retries each teamType until a clean full scrape (exit 0) or attempts exhausted. The CI bypass is flaky from GitHub's datacenter IP (back-to-back runs gave full / partial / total-block), and each attempt is an independent challenge solve — so retrying turns a coin-flip into a likely clean run. Tunable via `SCRAPE_MAX_ATTEMPTS` / `SCRAPE_RETRY_BACKOFF`.

### 4. Automated Convex prod deploy
`convex-deploy.yml` runs `npx convex deploy` on main when `convex/**` changes (existing `CONVEX_DEPLOY_KEY` secret), closing the gap where the Vercel build only ran `codegen` so prod Convex drifted from merged code. Isolated from Vercel — a failed deploy can't take down the site.

## Validated in CI today
- Full clean scrape → reconcile dry-run → 0 orphans → green (retry landed on attempt 1/3)
- Partial block → reconcile SKIPPED (guard)
- Total block → red (0-player fail-loud)

## Note
Research concluded the most reliable *free* path is running the scraper from a residential IP (a local `launchd` job on the Mac), since Cloudflare blocks datacenter ASNs. This PR keeps GitHub Actions as a hardened free **backup** / manual-trigger path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)