### PR TITLE
ci: weekly scrape cadence + 5 retries

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,9 +1,12 @@
 name: Scrape NBA 2K Ratings
 
 on:
-  # Run on the 1st and 15th of each month at 3 AM UTC
+  # Weekly, Saturday 03:00 UTC — catches 2K's typical Friday-evening roster
+  # drops. Weekly matches how often ratings actually change, so we stay fresh
+  # without hammering 2kratings (one polite collector; the API caches + serves
+  # everyone downstream, so this is the ONLY request load they ever see).
   schedule:
-    - cron: '0 3 1,15 * *'
+    - cron: '0 3 * * 6'
 
   # Allow manual trigger from GitHub UI
   workflow_dispatch:

--- a/scripts/scrape-retry.sh
+++ b/scripts/scrape-retry.sh
@@ -14,7 +14,7 @@
 set -u
 
 TEAM_TYPE="${1:?usage: scrape-retry.sh <curr|class|allt>}"
-MAX_ATTEMPTS="${SCRAPE_MAX_ATTEMPTS:-3}"
+MAX_ATTEMPTS="${SCRAPE_MAX_ATTEMPTS:-5}"
 BACKOFF_SECONDS="${SCRAPE_RETRY_BACKOFF:-30}"
 
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do


### PR DESCRIPTION
Rosters change ~weekly at most, so daily would be ~360 no-op scrapes. Switch cron from bi-weekly (1st/15th) to **weekly** (Sat 03:00 UTC, after 2K's Friday roster drops), and bump retries 3→5 so each weekly run is reliable on its own.

Lower footprint = lower ban risk, and since nba2kapi caches + serves all downstream consumers, this single weekly scrape is the only load 2kratings ever sees no matter how many apps build on the API.

Trivial config change: cron line + retry default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)