### PR TITLE
feat: playground reskin — sentence query, live table, JSON rail + richer API

### DIFF
--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -1,412 +1,640 @@
 "use client";
 
-import * as React from "react";
-import { Suspense } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useQuery } from "convex/react";
+import { toast } from "sonner";
 import { api } from "@/convex/_generated/api";
-import { useRouter, useSearchParams, usePathname } from "next/navigation";
-import { motion } from "framer-motion";
-import { Button } from "@/components/ui/button";
-import { LoadingCard } from "@/components/ui/loading-card";
-import { MasonryRoot, MasonryItem } from "@/components/ui/masonry";
-import { fadeIn } from "@/lib/animations";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import type { TeamType } from "@/types/player";
-import { parseFiltersFromURL, filtersToURLParams, type PlaygroundFilters } from "@/lib/playground-url";
-import { FilterBar } from "@/components/playground/filter-bar";
-import { FilterSheet } from "@/components/playground/filter-sheet";
-import { FilterPanel } from "@/components/playground/filter-panel";
-import { FlipCard } from "@/components/playground/flip-card";
-import { ExportActions } from "@/components/playground/export-actions";
+import { TopNav } from "@/components/chrome/top-nav";
+import { FooterStrip } from "@/components/chrome/footer-strip";
+import { Headshot } from "@/components/ui/headshot";
+import { getRatingClasses, getAttributeColor } from "@/lib/rating-colors";
+import { getTeamAbbreviation } from "@/lib/team-abbr";
+import { API_KEY_STORAGE_KEY } from "@/lib/constants";
+import { cn } from "@/lib/utils";
 
-// Card dimensions for column calculation
-const CARD_WIDTH = 160;
-const GAP = 12;
-const CONTAINER_PADDING = 32; // px-4 on each side = 16 * 2
-const ROWS_PER_PAGE = 4;
+// ---- Sentence slots -------------------------------------------------------
 
-export default function PlaygroundPage() {
+const POS_SLOTS = [
+  { label: "guards", param: "guard", positions: ["PG", "SG"] as string[] | null },
+  { label: "wings", param: "wing", positions: ["SG", "SF"] as string[] | null },
+  { label: "bigs", param: "big", positions: ["PF", "C"] as string[] | null },
+  { label: "anyone", param: "any", positions: null },
+];
+
+const ERA_SLOTS = [
+  { label: "any era", param: "all" },
+  { label: "the current league", param: "curr" },
+  { label: "the classics", param: "class" },
+];
+
+const THREE_SLOTS = [
+  { label: "3PT ≥ 80", v: 80 },
+  { label: "3PT ≥ 85", v: 85 },
+  { label: "3PT ≥ 90", v: 90 },
+  { label: "any 3PT", v: 0 },
+];
+
+type SortKey = "overall" | "tpt" | "spd" | "dnk" | "def";
+const SORT_KEYS: SortKey[] = ["overall", "tpt", "spd", "dnk", "def"];
+const SORT_LABELS: Record<SortKey, string> = {
+  overall: "overall",
+  tpt: "three ball",
+  spd: "speed",
+  dnk: "dunking",
+  def: "defense",
+};
+const SORT_URL_NAMES: Record<SortKey, string> = {
+  overall: "overall",
+  tpt: "three_ball",
+  spd: "speed",
+  dnk: "driving_dunk",
+  def: "perimeter_defense",
+};
+
+type PlaygroundPlayer = {
+  name: string;
+  slug: string;
+  team: string;
+  teamType: "curr" | "class" | "allt";
+  positions: string[];
+  overall: number;
+  playerImage: string | null;
+  threePointShot: number | null;
+  speed: number | null;
+  drivingDunk: number | null;
+  perimeterDefense: number | null;
+};
+
+const ATTR_OF: Record<Exclude<SortKey, "overall">, (p: PlaygroundPlayer) => number | null> = {
+  tpt: (p) => p.threePointShot,
+  spd: (p) => p.speed,
+  dnk: (p) => p.drivingDunk,
+  def: (p) => p.perimeterDefense,
+};
+
+const SAVED_QUERIES = [
+  { label: "Lockdown wings, any era", pos: 1, era: 0, three: 3, sortKey: "def" as SortKey, team: null },
+  { label: "7-footers who shoot 80+", pos: 2, era: 0, three: 0, sortKey: "tpt" as SortKey, team: null },
+  { label: "'96 Bulls full roster", pos: 3, era: 2, three: 3, sortKey: "overall" as SortKey, team: "1995-96 Chicago Bulls" },
+];
+
+const ROW_LIMIT = 50;
+
+// ---- Helpers ---------------------------------------------------------------
+
+function sortValue(p: PlaygroundPlayer, key: SortKey): number | null {
+  return key === "overall" ? p.overall : ATTR_OF[key](p);
+}
+
+function shortTeam(p: PlaygroundPlayer): string {
+  const abbr = getTeamAbbreviation(p.team);
+  if (p.teamType === "class") {
+    const match = p.team.match(/^\d{4}-(\d{2})\s/);
+    return match ? `${abbr} '${match[1]}` : abbr;
+  }
+  if (p.teamType === "allt") return `${abbr} A-T`;
+  return abbr;
+}
+
+function eraTag(teamType: PlaygroundPlayer["teamType"]) {
+  if (teamType === "class") return { label: "CLASSIC", color: "#9a6700" };
+  if (teamType === "allt") return { label: "ALL-TIME", color: "#9a6700" };
+  return { label: "CURRENT", color: "#8a8577" };
+}
+
+function OvrChip({ ovr }: { ovr: number }) {
   return (
-    <Suspense fallback={<PlaygroundLoading />}>
-      <PlaygroundContent />
-    </Suspense>
+    <span
+      className={cn(
+        "inline-flex w-[38px] items-center justify-center rounded-[6px] py-[3px] text-[12px] font-bold text-white tabular-nums",
+        getRatingClasses(ovr).bg
+      )}
+    >
+      {ovr}
+    </span>
   );
 }
 
-function PlaygroundLoading() {
+function AttrCell({ value, highlighted = false }: { value: number | null; highlighted?: boolean }) {
   return (
-    <div className="container py-8">
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        {Array.from({ length: 12 }).map((_, i) => (
-          <LoadingCard key={i} />
-        ))}
-      </div>
-    </div>
+    <span
+      className={cn(
+        "text-center text-[12.5px] font-bold tabular-nums",
+        highlighted && "rounded-[5px] bg-[#faf7ee] py-[3px]"
+      )}
+      style={{ color: value === null ? "#b5b0a1" : getAttributeColor(value) }}
+    >
+      {value ?? "—"}
+    </span>
   );
 }
 
-function PlaygroundContent() {
+function SlotChevron() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="#b5b0a1"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  );
+}
+
+function Slot({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex cursor-pointer items-center gap-1.5 border-b-2 border-dashed border-[#d9d4c7] px-[3px] pb-px font-extrabold text-[#1a1918] transition-[border-color] duration-150 select-none hover:border-[#1a1918] active:scale-[0.98]"
+    >
+      {label}
+      <SlotChevron />
+    </button>
+  );
+}
+
+// ---- URL <-> state ----------------------------------------------------------
+
+type QueryState = {
+  pos: number;
+  era: number;
+  three: number;
+  sortKey: SortKey;
+  sortDir: -1 | 1;
+  team: string | null;
+};
+
+function stateFromParams(sp: URLSearchParams): QueryState {
+  // Pristine /playground gets the design's showcase defaults. A URL that
+  // carries any query param is a deep link — unspecified slots must stay
+  // wide open ("anyone" / "any era" / "any 3PT") so the link isn't narrowed.
+  const isDeepLink = ["position", "era", "three_ball_gte", "sort", "team"].some((k) => sp.has(k));
+  if (!isDeepLink) {
+    return { pos: 0, era: 0, three: 1, sortKey: "overall", sortDir: -1, team: null };
+  }
+  const posIdx = POS_SLOTS.findIndex((s) => s.param === sp.get("position"));
+  const eraIdx = ERA_SLOTS.findIndex((s) => s.param === sp.get("era"));
+  const threeIdx = sp.has("three_ball_gte")
+    ? THREE_SLOTS.findIndex((s) => s.v === Number(sp.get("three_ball_gte")))
+    : -1;
+  const [sortField, sortDir] = (sp.get("sort") ?? "").split(":");
+  const sortKey =
+    (Object.entries(SORT_URL_NAMES).find(([, url]) => url === sortField)?.[0] as SortKey) ??
+    "overall";
+  return {
+    pos: posIdx >= 0 ? posIdx : 3,
+    era: eraIdx >= 0 ? eraIdx : 0,
+    three: threeIdx >= 0 ? threeIdx : 3,
+    sortKey,
+    sortDir: sortDir === "asc" ? 1 : -1,
+    team: sp.get("team"),
+  };
+}
+
+function paramsFromState(s: QueryState): string {
+  const params = new URLSearchParams();
+  const pos = POS_SLOTS[s.pos];
+  if (pos.param !== "any") params.set("position", pos.param);
+  params.set("era", ERA_SLOTS[s.era].param);
+  if (THREE_SLOTS[s.three].v > 0) params.set("three_ball_gte", String(THREE_SLOTS[s.three].v));
+  if (s.team) params.set("team", s.team);
+  params.set("sort", `${SORT_URL_NAMES[s.sortKey]}:${s.sortDir === -1 ? "desc" : "asc"}`);
+  return params.toString();
+}
+
+// ---- Page -----------------------------------------------------------------
+
+function Playground() {
   const router = useRouter();
-  const pathname = usePathname();
   const searchParams = useSearchParams();
+  const [q, setQ] = useState<QueryState>(() => stateFromParams(searchParams));
+  const [copied, setCopied] = useState(false);
+  const [hasApiKey, setHasApiKey] = useState(false);
 
-  // Parse initial state from URL
-  const initialFilters = React.useMemo(
-    () => parseFiltersFromURL(searchParams),
-    [searchParams]
-  );
+  const players = useQuery(api.players.getPlaygroundPlayers) as PlaygroundPlayer[] | undefined;
 
-  // Filter state
-  const [search, setSearch] = React.useState(initialFilters.search || "");
-  const [teamType, setTeamType] = React.useState<TeamType>(initialFilters.teamType || "curr");
-  const [selectedTeams, setSelectedTeams] = React.useState<string[]>(initialFilters.teams || []);
-  const [selectedPositions, setSelectedPositions] = React.useState<string[]>(
-    initialFilters.positions || []
-  );
-  const [overallRange, setOverallRange] = React.useState<[number, number]>([
-    initialFilters.minOverall ?? 0,
-    initialFilters.maxOverall ?? 99,
-  ]);
-  const [sortBy, setSortBy] = React.useState(initialFilters.sortBy || "overall-desc");
-  const [page, setPage] = React.useState(initialFilters.page || 1);
-
-  // Calculate columns based on viewport width
-  const [columns, setColumns] = React.useState(6); // Default for SSR
-
-  React.useEffect(() => {
-    const calculateColumns = () => {
-      const containerWidth = window.innerWidth - CONTAINER_PADDING;
-      // Max width is 1280px (max-w-7xl)
-      const effectiveWidth = Math.min(containerWidth, 1280 - CONTAINER_PADDING);
-      const cols = Math.floor((effectiveWidth + GAP) / (CARD_WIDTH + GAP));
-      setColumns(Math.max(1, cols));
-    };
-
-    calculateColumns();
-    window.addEventListener('resize', calculateColumns);
-    return () => window.removeEventListener('resize', calculateColumns);
+  useEffect(() => {
+    setHasApiKey(!!localStorage.getItem(API_KEY_STORAGE_KEY));
   }, []);
 
-  // Items per page based on columns to fill complete rows
-  const itemsPerPage = columns * ROWS_PER_PAGE;
+  // Keep the URL shareable: mirror the sentence into query params.
+  useEffect(() => {
+    const qs = paramsFromState(q);
+    if (qs !== searchParams.toString()) {
+      router.replace(`/playground?${qs}`, { scroll: false });
+    }
+  }, [q, router, searchParams]);
 
-  // Debounced search
-  const [debouncedSearch, setDebouncedSearch] = React.useState(search);
+  const requestUrl = `/api/players?${paramsFromState(q)}`;
 
-  React.useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearch(search), 300);
-    return () => clearTimeout(timer);
-  }, [search]);
+  const filtered = useMemo(() => {
+    if (!players) return [];
+    const pos = POS_SLOTS[q.pos];
+    const era = ERA_SLOTS[q.era].param;
+    const minThree = THREE_SLOTS[q.three].v;
+    const sign = q.sortDir;
+    return players
+      .filter((p) => {
+        if (pos.positions && !p.positions.some((x) => pos.positions!.includes(x))) return false;
+        if (era !== "all" && p.teamType !== era) return false;
+        if (minThree > 0 && (p.threePointShot === null || p.threePointShot < minThree)) return false;
+        if (q.team && p.team !== q.team) return false;
+        return true;
+      })
+      .sort((a, b) => {
+        const av = sortValue(a, q.sortKey);
+        const bv = sortValue(b, q.sortKey);
+        if (av === null && bv === null) return b.overall - a.overall;
+        if (av === null) return 1;
+        if (bv === null) return -1;
+        const d = sign === -1 ? bv - av : av - bv;
+        return d !== 0 ? d : b.overall - a.overall;
+      });
+  }, [players, q]);
 
-  // Fetch available teams for current team type
-  const teamsData = useQuery(api.teams.getAllTeams, { teamType });
-  const teams = React.useMemo(
-    () => (teamsData || []).map((t) => ({
-      name: t.name,
-      logo: t.logo,
-      playerCount: t.playerCount,
-      avgRating: t.avgRating,
-    })).sort((a, b) => a.name.localeCompare(b.name)),
-    [teamsData]
-  );
+  const rows = filtered.slice(0, ROW_LIMIT);
+  const first = filtered[0];
 
-  // Calculate offset for pagination
-  const offset = (page - 1) * itemsPerPage;
+  const cycle = (key: "pos" | "era" | "three", len: number) => () =>
+    setQ((s) => ({ ...s, [key]: (s[key] + 1) % len, team: null }));
 
-  // Fetch filtered players
-  const result = useQuery(api.players.getAllFiltered, {
-    search: debouncedSearch || undefined,
-    teamType,
-    teams: selectedTeams.length > 0 ? selectedTeams : undefined,
-    positions: selectedPositions.length > 0 ? selectedPositions : undefined,
-    minOverall: overallRange[0],
-    maxOverall: overallRange[1],
-    sortBy: sortBy as any,
-    limit: itemsPerPage,
-    offset,
-  });
+  const cycleSort = () =>
+    setQ((s) => ({
+      ...s,
+      sortKey: SORT_KEYS[(SORT_KEYS.indexOf(s.sortKey) + 1) % SORT_KEYS.length],
+      sortDir: -1,
+    }));
 
-  const players = result?.players || [];
-  const totalCount = result?.totalCount || 0;
-  const totalPages = Math.ceil(totalCount / itemsPerPage);
+  const sortBy = (key: SortKey) => () =>
+    setQ((s) => ({
+      ...s,
+      sortKey: key,
+      sortDir: s.sortKey === key ? ((-s.sortDir) as -1 | 1) : -1,
+    }));
 
-  // Sync filters to URL (debounced)
-  React.useEffect(() => {
-    const timer = setTimeout(() => {
-      const filters: PlaygroundFilters = {
-        search: debouncedSearch || undefined,
-        teamType,
-        teams: selectedTeams.length > 0 ? selectedTeams : undefined,
-        positions: selectedPositions.length > 0 ? selectedPositions : undefined,
-        minOverall: overallRange[0] !== 0 ? overallRange[0] : undefined,
-        maxOverall: overallRange[1] !== 99 ? overallRange[1] : undefined,
-        sortBy: sortBy !== "overall-desc" ? sortBy : undefined,
-        page: page !== 1 ? page : undefined,
-      };
+  const arrow = (key: SortKey) => (q.sortKey === key ? (q.sortDir === -1 ? " ↓" : " ↑") : "");
+  const headColor = (key: SortKey) => (q.sortKey === key ? "#1a1918" : "#b5b0a1");
 
-      const params = filtersToURLParams(filters);
-      const newURL = params.toString() ? `${pathname}?${params.toString()}` : pathname;
-      router.replace(newURL, { scroll: false });
-    }, 500);
+  const copyUrl = () => {
+    navigator.clipboard.writeText(`https://api.nba2kapi.com${requestUrl}`).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    });
+  };
 
-    return () => clearTimeout(timer);
-  }, [debouncedSearch, teamType, selectedTeams, selectedPositions, overallRange, sortBy, page, pathname, router]);
-
-  // Reset page when filters change
-  React.useEffect(() => {
-    setPage(1);
-  }, [debouncedSearch, teamType, selectedTeams, selectedPositions, overallRange, sortBy]);
-
-  // Clear selected teams when teamType changes
-  React.useEffect(() => {
-    setSelectedTeams([]);
-  }, [teamType]);
-
-  // Toggle position filter
-  const togglePosition = (position: string) => {
-    setSelectedPositions((prev) =>
-      prev.includes(position)
-        ? prev.filter((p) => p !== position)
-        : [...prev, position]
+  const exportCsv = () => {
+    const header = "name,slug,team,era,overall,three_ball,speed,driving_dunk,perimeter_defense";
+    const lines = filtered.map((p) =>
+      [
+        `"${p.name.replace(/"/g, '""')}"`,
+        p.slug,
+        `"${p.team.replace(/"/g, '""')}"`,
+        p.teamType,
+        p.overall,
+        p.threePointShot ?? "",
+        p.speed ?? "",
+        p.drivingDunk ?? "",
+        p.perimeterDefense ?? "",
+      ].join(",")
     );
+    const blob = new Blob([[header, ...lines].join("\n")], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "nba2kapi-query.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+    toast.success(`Exported ${filtered.length} players`);
   };
 
-  // Toggle team filter
-  const toggleTeam = (team: string) => {
-    setSelectedTeams((prev) =>
-      prev.includes(team) ? prev.filter((t) => t !== team) : [...prev, team]
-    );
+  const copyJson = () => {
+    const payload = {
+      success: true,
+      count: filtered.length,
+      results: filtered.map((p) => ({
+        name: p.name,
+        slug: p.slug,
+        team: p.team,
+        era: p.teamType,
+        overall: p.overall,
+        three_ball: p.threePointShot,
+        speed: p.speed,
+        driving_dunk: p.drivingDunk,
+        perimeter_defense: p.perimeterDefense,
+      })),
+    };
+    navigator.clipboard
+      .writeText(JSON.stringify(payload, null, 2))
+      .then(() => toast.success("Response JSON copied"));
   };
 
-  // Clear all selected teams
-  const clearTeams = () => {
-    setSelectedTeams([]);
-  };
+  const applySaved = (s: (typeof SAVED_QUERIES)[number]) =>
+    setQ({ pos: s.pos, era: s.era, three: s.three, sortKey: s.sortKey, sortDir: -1, team: s.team });
 
-  // Clear all filters
-  const clearFilters = () => {
-    setSearch("");
-    setTeamType("curr");
-    setSelectedTeams([]);
-    setSelectedPositions([]);
-    setOverallRange([0, 99]);
-    setSortBy("overall-desc");
-    setPage(1);
-  };
-
-  const hasActiveFilters =
-    !!search ||
-    selectedTeams.length > 0 ||
-    selectedPositions.length > 0 ||
-    overallRange[0] !== 0 ||
-    overallRange[1] !== 99;
-
-  const activeFilterCount =
-    (search ? 1 : 0) +
-    selectedTeams.length +
-    selectedPositions.length +
-    (overallRange[0] !== 0 || overallRange[1] !== 99 ? 1 : 0);
+  const monoHead = "font-plex text-[8.5px] tracking-[0.08em]";
+  const rowGrid =
+    "grid grid-cols-[34px_30px_minmax(150px,1fr)_80px_54px_54px_repeat(3,46px)] items-center gap-2.5 px-4";
 
   return (
-    <div className="container mx-auto max-w-7xl px-4 py-8">
-      {/* Header */}
-      <motion.div
-        variants={fadeIn}
-        initial="initial"
-        animate="animate"
-        className="mb-6 space-y-2"
-      >
-        <h1 className="text-5xl font-bold tracking-tight font-rajdhani bg-clip-text text-transparent bg-gradient-to-r from-foreground to-foreground/70">Player Playground</h1>
-        <p className="text-lg text-muted-foreground font-rajdhani tracking-wide">
-          Explore and filter {totalCount.toLocaleString()} NBA 2K players
-        </p>
-      </motion.div>
+    <div className="min-h-screen bg-[#faf9f5] font-body text-[#1a1918]">
+      <TopNav hasApiKey={hasApiKey} wide />
 
-      {/* Mobile Filter Sheet */}
-      <div className="lg:hidden mb-4">
-        <FilterSheet activeFilterCount={activeFilterCount}>
-          <FilterPanel
-            search={search}
-            setSearch={setSearch}
-            teamType={teamType}
-            setTeamType={setTeamType}
-            teams={teams}
-            selectedTeams={selectedTeams}
-            toggleTeam={toggleTeam}
-            clearTeams={clearTeams}
-            selectedPositions={selectedPositions}
-            togglePosition={togglePosition}
-            overallRange={overallRange}
-            setOverallRange={setOverallRange}
-            sortBy={sortBy}
-            setSortBy={setSortBy}
-            hasActiveFilters={hasActiveFilters}
-            clearFilters={clearFilters}
-            showHeader={false}
-          />
-        </FilterSheet>
+      {/* Query card */}
+      <div className="mx-auto max-w-[1440px] animate-[rise-in_400ms_cubic-bezier(0.23,1,0.32,1)_both] px-[clamp(20px,4vw,48px)] pt-2 motion-reduce:animate-none">
+        <div className="rounded-2xl border border-[#e5e2da] bg-white p-[clamp(16px,2.5vw,24px)]">
+          <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+            <span className="font-plex text-[9.5px] tracking-[0.12em] text-[#8a8577]">
+              QUERY — CLICK ANY SLOT TO CHANGE IT
+            </span>
+            <span className="font-plex text-[9px] text-[#b5b0a1]">SAVED QUERIES →</span>
+          </div>
+          <div className="font-display text-[clamp(19px,2.2vw,25px)] leading-[1.7] font-semibold tracking-[-0.02em] text-[#57534a]">
+            Show me <Slot label={POS_SLOTS[q.pos].label} onClick={cycle("pos", POS_SLOTS.length)} />{" "}
+            from <Slot label={ERA_SLOTS[q.era].label} onClick={cycle("era", ERA_SLOTS.length)} />{" "}
+            with{" "}
+            <Slot label={THREE_SLOTS[q.three].label} onClick={cycle("three", THREE_SLOTS.length)} />
+            , ranked by <Slot label={SORT_LABELS[q.sortKey]} onClick={cycleSort} />
+          </div>
+          <div className="mt-3.5 flex items-center overflow-hidden rounded-[10px] bg-[#1a1918]">
+            <span className="shrink-0 bg-white/12 px-[13px] py-[9px] font-plex text-[9.5px] text-[#faf9f5]">
+              GET
+            </span>
+            <span className="flex-1 overflow-hidden px-3.5 font-plex text-[11px] text-ellipsis whitespace-nowrap text-[#faf9f5]">
+              {requestUrl}
+            </span>
+            <button
+              type="button"
+              onClick={copyUrl}
+              className="shrink-0 cursor-pointer border-l border-white/12 px-3.5 py-[9px] font-plex text-[9.5px] text-white/70 transition-colors duration-150 hover:text-white"
+            >
+              {copied ? "COPIED ✓" : "COPY"}
+            </button>
+          </div>
+        </div>
       </div>
 
-      {/* Desktop Horizontal Filter Bar */}
-      <div className="hidden lg:block">
-        <FilterBar
-          search={search}
-          setSearch={setSearch}
-          teamType={teamType}
-          setTeamType={setTeamType}
-          teams={teams}
-          selectedTeams={selectedTeams}
-          toggleTeam={toggleTeam}
-          clearTeams={clearTeams}
-          selectedPositions={selectedPositions}
-          togglePosition={togglePosition}
-          overallRange={overallRange}
-          setOverallRange={setOverallRange}
-          sortBy={sortBy}
-          setSortBy={setSortBy}
-          hasActiveFilters={hasActiveFilters}
-          clearFilters={clearFilters}
-        />
+      {/* Meta strip */}
+      <div className="mx-auto flex max-w-[1440px] flex-wrap items-center justify-between gap-2.5 px-[clamp(20px,4vw,48px)] pt-3.5">
+        <span className="flex flex-wrap items-center gap-2 font-plex text-[10px] tracking-[0.08em] text-[#8a8577]">
+          <span>
+            <b className="text-[#1a1918]">{players ? `${filtered.length} MATCH` : "LOADING"}</b> ·
+            CACHED 1H
+          </span>
+          {q.team && (
+            <button
+              type="button"
+              onClick={() => setQ((s) => ({ ...s, team: null }))}
+              className="cursor-pointer rounded-full border border-[#e5e2da] bg-white px-2.5 py-0.5 font-plex text-[9px] tracking-[0.08em] text-[#57534a] hover:border-[#1a1918]"
+              title="Clear team filter"
+            >
+              TEAM: {q.team.toUpperCase()} ✕
+            </button>
+          )}
+        </span>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={exportCsv}
+            className="cursor-pointer rounded-full border border-[#e5e2da] bg-white px-[13px] py-1.5 text-[11.5px] font-semibold text-[#1a1918] transition-[border-color,transform] duration-150 hover:border-[#1a1918] active:scale-[0.97] motion-reduce:transition-none"
+          >
+            Export CSV
+          </button>
+          <button
+            type="button"
+            onClick={copyJson}
+            className="cursor-pointer rounded-full border border-[#e5e2da] bg-white px-[13px] py-1.5 text-[11.5px] font-semibold text-[#1a1918] transition-[border-color,transform] duration-150 hover:border-[#1a1918] active:scale-[0.97] motion-reduce:transition-none"
+          >
+            Copy JSON
+          </button>
+        </div>
       </div>
 
-      {/* Player Grid - Full Width */}
-      <div className="mt-6 space-y-6">
-        {/* Results count, export actions, and pagination info */}
-        {result !== undefined && totalCount > 0 && (
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-sm text-muted-foreground">
-              Showing {offset + 1}-{Math.min(offset + itemsPerPage, totalCount)} of{" "}
-              {totalCount.toLocaleString()} players
-            </p>
-            <div className="flex items-center gap-3 sm:gap-4">
-              <ExportActions
-                search={debouncedSearch}
-                teamType={teamType}
-                teams={selectedTeams}
-                positions={selectedPositions}
-                minOverall={overallRange[0]}
-                maxOverall={overallRange[1]}
-                sortBy={sortBy}
-                totalCount={totalCount}
-              />
-              {totalPages > 1 && (
-                <p className="text-sm text-muted-foreground whitespace-nowrap">
-                  Page {page} of {totalPages}
-                </p>
+      {/* Results + rail */}
+      <div className="mx-auto grid max-w-[1440px] grid-cols-[repeat(auto-fit,minmax(min(100%,620px),1fr))] items-start gap-3.5 px-[clamp(20px,4vw,48px)] pt-2.5 pb-12">
+        {/* Table */}
+        <div
+          className="overflow-hidden rounded-[14px] border border-[#e5e2da] bg-white animate-[rise-in_400ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
+          style={{ animationDelay: "80ms" }}
+        >
+          <div className="overflow-x-auto">
+            <div className="min-w-[655px]">
+              <div className={cn(rowGrid, "border-b border-[#e5e2da] bg-[#faf9f5] py-[9px]")}>
+                <span className={cn(monoHead, "text-[#b5b0a1]")}>#</span>
+                <span />
+                <span className={cn(monoHead, "text-[#b5b0a1]")}>PLAYER</span>
+                <span className={cn(monoHead, "text-[#b5b0a1]")}>ERA</span>
+                <button
+                  type="button"
+                  onClick={sortBy("overall")}
+                  className={cn(monoHead, "cursor-pointer text-left font-bold select-none")}
+                  style={{ color: headColor("overall") }}
+                >
+                  OVR{arrow("overall")}
+                </button>
+                <button
+                  type="button"
+                  onClick={sortBy("tpt")}
+                  className={cn(
+                    monoHead,
+                    "cursor-pointer rounded-[5px] bg-[#f6f2e6] py-0.5 text-center font-bold text-[#1a1918] select-none"
+                  )}
+                >
+                  3PT{arrow("tpt")} ●
+                </button>
+                {(["spd", "dnk", "def"] as const).map((key) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={sortBy(key)}
+                    className={cn(
+                      monoHead,
+                      "cursor-pointer text-center transition-colors duration-150 select-none hover:text-[#1a1918]"
+                    )}
+                    style={{ color: headColor(key) }}
+                  >
+                    {key.toUpperCase()}
+                    {arrow(key)}
+                  </button>
+                ))}
+              </div>
+
+              {players
+                ? rows.map((p, i) => {
+                    const era = eraTag(p.teamType);
+                    return (
+                      <Link
+                        key={`${p.slug}-${p.teamType}-${p.team}`}
+                        href={`/players/${p.slug}`}
+                        className={cn(
+                          rowGrid,
+                          "border-b border-[#faf8f2] py-[7px] text-[#1a1918] no-underline transition-colors duration-100 hover:bg-[#faf8f2]"
+                        )}
+                      >
+                        <span className="font-plex text-[10px] text-[#b5b0a1]">{i + 1}</span>
+                        <Headshot src={p.playerImage} name={p.name} size={28} />
+                        <div className="flex min-w-0 items-baseline gap-2">
+                          <span className="overflow-hidden text-[13px] font-semibold text-ellipsis whitespace-nowrap">
+                            {p.name}
+                          </span>
+                          <span className="whitespace-nowrap font-plex text-[8.5px] text-[#8a8577]">
+                            {p.positions.join("/")} · {shortTeam(p)}
+                          </span>
+                        </div>
+                        <span
+                          className="font-plex text-[8px] font-bold tracking-[0.08em]"
+                          style={{ color: era.color }}
+                        >
+                          {era.label}
+                        </span>
+                        <OvrChip ovr={p.overall} />
+                        <AttrCell value={p.threePointShot} highlighted />
+                        <AttrCell value={p.speed} />
+                        <AttrCell value={p.drivingDunk} />
+                        <AttrCell value={p.perimeterDefense} />
+                      </Link>
+                    );
+                  })
+                : Array.from({ length: 12 }, (_, i) => (
+                    <div
+                      key={i}
+                      className={cn(rowGrid, "animate-pulse border-b border-[#faf8f2] py-[7px]")}
+                    >
+                      <span className="h-3 w-4 rounded bg-[#f1efe8]" />
+                      <div className="h-7 w-7 rounded-full bg-[#f1efe8]" />
+                      <span className="h-3.5 w-2/3 rounded bg-[#f1efe8]" />
+                      <span className="h-3 w-12 rounded bg-[#f1efe8]" />
+                      <span className="h-[22px] w-[38px] rounded-[6px] bg-[#f1efe8]" />
+                      <span className="h-[22px] rounded-[5px] bg-[#f1efe8]" />
+                      <span className="h-3 rounded bg-[#f1efe8]" />
+                      <span className="h-3 rounded bg-[#f1efe8]" />
+                      <span className="h-3 rounded bg-[#f1efe8]" />
+                    </div>
+                  ))}
+
+              {players && rows.length === 0 && (
+                <div className="px-4 py-10 text-center">
+                  <div className="font-display text-[17px] font-bold">No players match</div>
+                  <div className="mt-1 text-[12.5px] text-[#8a8577]">
+                    Loosen a slot — try &quot;any 3PT&quot; or &quot;any era&quot;.
+                  </div>
+                </div>
               )}
             </div>
           </div>
-        )}
-
-        {/* Loading state */}
-        {result === undefined ? (
-          <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-            {Array.from({ length: 15 }).map((_, i) => (
-              <LoadingCard key={i} variant="player" />
-            ))}
+          <div className="flex flex-wrap items-center justify-between gap-2 bg-[#faf9f5] px-4 py-2">
+            <span className="font-plex text-[8.5px] text-[#b5b0a1]">
+              ● = QUERIED COLUMN · CLICK A COLUMN TO SORT · CLICK A ROW → DOSSIER
+            </span>
+            <span className="font-plex text-[8.5px] text-[#b5b0a1]">
+              SHOWING {rows.length} OF {filtered.length}
+            </span>
           </div>
-        ) : players.length === 0 ? (
-          /* Empty state */
-          <motion.div
-            variants={fadeIn}
-            initial="initial"
-            animate="animate"
-            className="text-center py-12"
-          >
-            <p className="text-lg text-muted-foreground">
-              No players found matching your filters
+        </div>
+
+        {/* Right rail */}
+        <div
+          className="flex flex-col gap-2.5 animate-[rise-in_400ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
+          style={{ animationDelay: "140ms" }}
+        >
+          <div className="rounded-[14px] bg-[#1a1918] px-4 py-3.5">
+            <div className="mb-2.5 flex items-center justify-between">
+              <span className="font-plex text-[9px] tracking-[0.1em] text-white/60">RESPONSE</span>
+              <span className="font-plex text-[8.5px] text-[#6ee7a0]">
+                {players ? "200 OK · LIVE" : "LOADING…"}
+              </span>
+            </div>
+            <pre className="m-0 overflow-hidden font-plex text-[10px] leading-[1.65] text-white/85">
+              {"{\n  "}
+              <span className="text-[#8ab4f8]">&quot;success&quot;</span>
+              {": true,\n  "}
+              <span className="text-[#8ab4f8]">&quot;count&quot;</span>
+              {`: ${filtered.length},\n  `}
+              <span className="text-[#8ab4f8]">&quot;results&quot;</span>
+              {": [\n"}
+              {first ? (
+                <>
+                  {"    {\n      "}
+                  <span className="text-[#8ab4f8]">&quot;name&quot;</span>
+                  {": "}
+                  <span className="text-[#e6b36a]">&quot;{first.name}&quot;</span>
+                  {",\n      "}
+                  <span className="text-[#8ab4f8]">&quot;slug&quot;</span>
+                  {": "}
+                  <span className="text-[#e6b36a]">&quot;{first.slug}&quot;</span>
+                  {",\n      "}
+                  <span className="text-[#8ab4f8]">&quot;overall&quot;</span>
+                  {": "}
+                  <span className="text-[#b79ce0]">{first.overall}</span>
+                  {",\n      "}
+                  <span className="text-[#8ab4f8]">&quot;three_ball&quot;</span>
+                  {": "}
+                  <span className="text-[#b79ce0]">{first.threePointShot ?? "null"}</span>
+                  {",\n      "}
+                  <span className="text-[#8ab4f8]">&quot;era&quot;</span>
+                  {": "}
+                  <span className="text-[#e6b36a]">&quot;{first.teamType}&quot;</span>
+                  {"\n    },\n    "}
+                  <span className="text-white/40">…{Math.max(0, filtered.length - 1)} more</span>
+                  {"\n"}
+                </>
+              ) : (
+                <span className="text-white/40">{"    …\n"}</span>
+              )}
+              {"  ]\n}"}
+            </pre>
+          </div>
+
+          <div className="rounded-[14px] border border-[#e5e2da] bg-white px-4 py-3">
+            <div className="mb-2 font-plex text-[9px] tracking-[0.1em] text-[#8a8577]">
+              TRIM THE PAYLOAD
+            </div>
+            <p className="m-0 text-[11.5px] leading-[1.5] text-[#57534a]">
+              Add{" "}
+              <span className="rounded-[5px] border border-[#e5e2da] bg-[#faf9f5] px-[5px] py-px font-plex text-[10px]">
+                ?fields=name,overall
+              </span>{" "}
+              to get only the columns you need.
             </p>
-            <Button onClick={clearFilters} className="mt-4">
-              Clear Filters
-            </Button>
-          </motion.div>
-        ) : (
-          /* Player masonry grid */
-          <>
-            <MasonryRoot
-              key={`${page}-${teamType}`}
-              columnWidth={160}
-              gap={{ column: 12, row: 12 }}
-              itemHeight={240}
-              overscan={3}
-              linear
-              defaultWidth={1200}
-              defaultHeight={800}
-              fallback={
-                <div className="grid gap-3 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-                  {Array.from({ length: 24 }).map((_, i) => (
-                    <LoadingCard key={i} variant="player" />
-                  ))}
-                </div>
-              }
-            >
-              {players.map((player) => (
-                <MasonryItem key={player._id}>
-                  <motion.div
-                    initial={{ opacity: 0, scale: 0.95 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
-                  >
-                    <FlipCard player={player} />
-                  </motion.div>
-                </MasonryItem>
+          </div>
+
+          <div className="rounded-[14px] border border-[#e5e2da] bg-white px-4 py-3">
+            <div className="mb-2 font-plex text-[9px] tracking-[0.1em] text-[#8a8577]">
+              SAVED QUERIES
+            </div>
+            <div className="flex flex-col items-start gap-1.5">
+              {SAVED_QUERIES.map((s) => (
+                <button
+                  key={s.label}
+                  type="button"
+                  onClick={() => applySaved(s)}
+                  className="cursor-pointer text-left text-[11.5px] font-semibold text-[#1a1918] transition-colors duration-150 hover:text-[#57534a]"
+                >
+                  {s.label}
+                </button>
               ))}
-            </MasonryRoot>
-
-            {/* Pagination Controls */}
-            {totalPages > 1 && (
-              <div className="flex items-center justify-center gap-2 mt-8">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setPage((p) => Math.max(1, p - 1))}
-                  disabled={page === 1}
-                >
-                  <ChevronLeft className="h-4 w-4 mr-1" />
-                  Previous
-                </Button>
-
-                <div className="flex items-center gap-1">
-                  {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
-                    let pageNum: number;
-                    if (totalPages <= 5) {
-                      pageNum = i + 1;
-                    } else if (page <= 3) {
-                      pageNum = i + 1;
-                    } else if (page >= totalPages - 2) {
-                      pageNum = totalPages - 4 + i;
-                    } else {
-                      pageNum = page - 2 + i;
-                    }
-
-                    return (
-                      <Button
-                        key={pageNum}
-                        variant={page === pageNum ? "default" : "outline"}
-                        size="sm"
-                        onClick={() => setPage(pageNum)}
-                        className="w-10"
-                      >
-                        {pageNum}
-                      </Button>
-                    );
-                  })}
-                </div>
-
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                  disabled={page === totalPages}
-                >
-                  Next
-                  <ChevronRight className="h-4 w-4 ml-1" />
-                </Button>
-              </div>
-            )}
-          </>
-        )}
+            </div>
+          </div>
+        </div>
       </div>
+
+      <FooterStrip wide />
     </div>
+  );
+}
+
+export default function PlaygroundPage() {
+  return (
+    <Suspense fallback={null}>
+      <Playground />
+    </Suspense>
   );
 }

--- a/components/chrome/footer-strip.tsx
+++ b/components/chrome/footer-strip.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+
+/**
+ * Compact one-line footer used by data-dense reskinned pages (Playground,
+ * Board, Whiteboard). Marketing-weight pages use SiteFooter instead.
+ */
+export function FooterStrip({ wide = false }: { wide?: boolean }) {
+  return (
+    <div className="border-t border-[#e5e2da] bg-[#f5f3ec]">
+      <div
+        className={cn(
+          "mx-auto flex flex-wrap items-center justify-between gap-2.5 px-[clamp(20px,4vw,48px)] py-[18px] font-plex text-[11px] text-[#8a8577]",
+          wide ? "max-w-[1440px]" : "max-w-[1360px]"
+        )}
+      >
+        <span className="font-display text-[15px] font-extrabold text-[#1a1918]">nba2kapi</span>
+        <span>Data from 2kratings.com · Not affiliated with 2K Sports or the NBA</span>
+        <Link
+          href="/docs"
+          className="text-[#57534a] no-underline transition-colors duration-150 hover:text-[#1a1918]"
+        >
+          API Docs →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/chrome/top-nav.tsx
+++ b/components/chrome/top-nav.tsx
@@ -58,13 +58,15 @@ type TopNavProps = {
   onCtaClick?: () => void;
   /** Swaps the CTA label for returning users who already hold a key. */
   hasApiKey?: boolean;
+  /** Data-dense pages (Playground, Board, Whiteboard) run a 1440px shell. */
+  wide?: boolean;
 };
 
 /**
  * Shared chrome for reskinned (paper/editorial) pages: wordmark, pill nav,
  * search pill, GitHub star chip, and the primary API-key CTA.
  */
-export function TopNav({ onCtaClick, hasApiKey = false }: TopNavProps) {
+export function TopNav({ onCtaClick, hasApiKey = false, wide = false }: TopNavProps) {
   const ctaLabel = hasApiKey ? "View dashboard" : "Get an API key";
   const pathname = usePathname();
   const router = useRouter();
@@ -92,7 +94,12 @@ export function TopNav({ onCtaClick, hasApiKey = false }: TopNavProps) {
     "rounded-full bg-[#1a1918] px-5 py-2.5 text-[13.5px] font-semibold text-[#faf9f5] no-underline transition-[background,transform] duration-150 ease-out hover:bg-[#333] active:scale-[0.97] motion-reduce:transition-none";
 
   return (
-    <div className="mx-auto flex w-full max-w-[1360px] flex-wrap items-center justify-between gap-3 px-[clamp(20px,4vw,48px)] py-5">
+    <div
+      className={cn(
+        "mx-auto flex w-full flex-wrap items-center justify-between gap-3 px-[clamp(20px,4vw,48px)] py-5",
+        wide ? "max-w-[1440px]" : "max-w-[1360px]"
+      )}
+    >
       <Link
         href="/"
         className="font-display text-[22px] font-extrabold tracking-[-0.02em] text-[#1a1918] no-underline"

--- a/components/legacy-chrome.tsx
+++ b/components/legacy-chrome.tsx
@@ -7,7 +7,7 @@ import { Footer } from "@/components/footer";
 // Routes that have been migrated to the new (paper/editorial) design render
 // their own chrome (TopNav / SiteFooter) inside the page, so the legacy
 // header/footer must not double up on them.
-const RESKINNED_ROUTES = new Set(["/"]);
+const RESKINNED_ROUTES = new Set(["/", "/playground"]);
 
 export function LegacyHeader() {
   const pathname = usePathname();

--- a/components/ui/headshot.tsx
+++ b/components/ui/headshot.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+
+function initials(name: string) {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase();
+}
+
+type HeadshotProps = {
+  src: string | null | undefined;
+  name: string;
+  /** Rendered size in px (square). */
+  size: number;
+  className?: string;
+};
+
+/**
+ * Circular player headshot with a monogram fallback when the image is missing
+ * or 404s upstream (some scraped 2kratings URLs are stale). Served through the
+ * Next image optimizer because 2kratings blocks hotlinking.
+ */
+export function Headshot({ src, name, size, className }: HeadshotProps) {
+  const [errored, setErrored] = useState(false);
+  const showImage = src && !errored;
+
+  return (
+    <div
+      className={cn(
+        "relative flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#f1efe8] font-display font-extrabold text-[#57534a]",
+        className
+      )}
+      style={{ width: size, height: size, fontSize: Math.max(8, Math.round(size * 0.36)) }}
+    >
+      {showImage ? (
+        <Image
+          src={src}
+          alt={name}
+          fill
+          sizes={`${size}px`}
+          className="object-cover object-top"
+          onError={() => setErrored(true)}
+        />
+      ) : (
+        initials(name)
+      )}
+    </div>
+  );
+}

--- a/convex/_validation.ts
+++ b/convex/_validation.ts
@@ -137,17 +137,82 @@ export const PARAM_SUGGESTIONS: Record<string, ParamSuggestion> = {
 };
 
 /**
+ * Canonical player attribute keys (as stored in players.attributes).
+ * Kept in sync with lib/attribute-normalizer.ts ATTRIBUTE_NAME_MAP values.
+ */
+export const CANONICAL_ATTRIBUTES = [
+  "closeShot",
+  "drivingLayup",
+  "drivingDunk",
+  "standingDunk",
+  "postHook",
+  "postFade",
+  "postControl",
+  "midRangeShot",
+  "threePointShot",
+  "freeThrow",
+  "shotIQ",
+  "offensiveConsistency",
+  "drawFoul",
+  "hands",
+  "passAccuracy",
+  "ballHandle",
+  "speedWithBall",
+  "passIQ",
+  "passVision",
+  "passPerception",
+  "interiorDefense",
+  "perimeterDefense",
+  "steal",
+  "block",
+  "defensiveConsistency",
+  "defensiveRebound",
+  "lateralQuickness",
+  "helpDefenseIQ",
+  "speed",
+  "acceleration",
+  "agility",
+  "vertical",
+  "strength",
+  "stamina",
+  "hustle",
+  "durability",
+  "offensiveRebound",
+  "passing",
+  "postMoves",
+] as const;
+
+const toSnake = (key: string) => key.replace(/([A-Z])/g, "_$1").toLowerCase();
+
+/**
+ * Query-param spelling → canonical attribute key. Accepts snake_case of every
+ * canonical attribute plus a few friendly aliases used across the product
+ * (e.g. three_ball_gte=85, sort=three_ball:desc).
+ */
+export const ATTRIBUTE_PARAM_ALIASES: Record<string, string> = {
+  ...Object.fromEntries(CANONICAL_ATTRIBUTES.map((key) => [toSnake(key), key])),
+  three_ball: "threePointShot",
+  dunk: "drivingDunk",
+  defense: "perimeterDefense",
+};
+
+/**
  * Valid parameters for each endpoint
  */
 export const VALID_PARAMS_BY_ENDPOINT: Record<string, Set<string>> = {
   "/api/players": new Set([
     "teamType",
+    "era",
     "team",
     "minRating",
     "maxRating",
     "position",
+    "sort",
+    "fields",
     "cursor",
     "limit",
+    // Per-attribute range filters (three_ball_gte, speed_lte, …) are
+    // appended programmatically below the map.
   ]),
   "/api/public/players": new Set([
     "teamType",
@@ -180,6 +245,13 @@ export const VALID_PARAMS_BY_ENDPOINT: Record<string, Set<string>> = {
   "/api/badges/:slug/players": new Set(["tier", "limit"]),
   "/api/dashboard/usage": new Set([]),
 };
+
+// Register every attribute range filter (<alias>_gte / <alias>_lte) as a valid
+// /api/players param.
+for (const alias of Object.keys(ATTRIBUTE_PARAM_ALIASES)) {
+  VALID_PARAMS_BY_ENDPOINT["/api/players"].add(`${alias}_gte`);
+  VALID_PARAMS_BY_ENDPOINT["/api/players"].add(`${alias}_lte`);
+}
 
 /**
  * Detected unknown parameter with suggestion

--- a/convex/_validation.ts
+++ b/convex/_validation.ts
@@ -182,7 +182,8 @@ export const CANONICAL_ATTRIBUTES = [
   "postMoves",
 ] as const;
 
-const toSnake = (key: string) => key.replace(/([A-Z])/g, "_$1").toLowerCase();
+// Treat a run of capitals as one unit so shotIQ → shot_iq, not shot_i_q.
+const toSnake = (key: string) => key.replace(/([A-Z]+)/g, (m) => "_" + m.toLowerCase());
 
 /**
  * Query-param spelling → canonical attribute key. Accepts snake_case of every

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -16,6 +16,7 @@ import {
   detectUnknownParams,
   formatUnknownParamsError,
   VALID_PARAMS_BY_ENDPOINT,
+  ATTRIBUTE_PARAM_ALIASES,
 } from "./_validation";
 
 const app: HonoWithConvex<ActionCtx> = new Hono();
@@ -671,15 +672,33 @@ app.get("/api/admin/scrape/:jobId",
 // ============================================================================
 
 // GET /api/players - List players with filtering and pagination
+// Position groups accepted by ?position= alongside exact positions (PG..C).
+const POSITION_GROUPS: Record<string, string[]> = {
+  guard: ["PG", "SG"],
+  wing: ["SG", "SF"],
+  big: ["PF", "C"],
+};
+
+// Top-level player fields that ?fields= may project.
+const PROJECTABLE_FIELDS = new Set([
+  "name", "slug", "team", "teamType", "overall", "positions",
+  "height", "weight", "wingspan", "archetype", "college",
+  "playerImage", "teamImg", "attributes", "badges", "lastUpdated",
+]);
+
 app.get("/api/players",
   authMiddleware,
   rejectUnknownParams("/api/players"),
   zValidator("query", z.object({
     teamType: z.enum(["curr", "class", "allt"]).default("curr"),
+    // era supersedes teamType; "all" merges current + classic + all-time.
+    era: z.enum(["all", "curr", "class", "allt"]).optional(),
     team: z.string().optional(),
     minRating: z.coerce.number().min(0).max(99).optional(),
     maxRating: z.coerce.number().min(0).max(99).optional(),
     position: z.string().optional(),
+    sort: z.string().optional(),
+    fields: z.string().optional(),
     cursor: z.string().optional(),
     limit: z.coerce.number().min(1).max(100).default(50),
   })),
@@ -698,19 +717,83 @@ app.get("/api/players",
 
       // Build query args, only including defined values
       const queryArgs: any = {
-        teamType: params.teamType,
         sortBy: "overall-desc",
         limit: params.limit,
         offset: offset,
       };
 
+      // era=all means no teamType filter at all
+      const era = params.era ?? params.teamType;
+      if (era !== "all") queryArgs.teamType = era;
+
       if (params.team) queryArgs.teams = [params.team];
       if (params.minRating !== undefined) queryArgs.minOverall = params.minRating;
       if (params.maxRating !== undefined) queryArgs.maxOverall = params.maxRating;
-      if (params.position) queryArgs.positions = [params.position];
+      if (params.position) {
+        const group = POSITION_GROUPS[params.position.toLowerCase()];
+        queryArgs.positions = group ?? [params.position.toUpperCase()];
+      }
+
+      // Per-attribute range filters: <alias>_gte / <alias>_lte
+      const attributeFilters = new Map<string, { key: string; gte?: number; lte?: number }>();
+      const url = new URL(c.req.url);
+      for (const [key, value] of url.searchParams.entries()) {
+        const match = key.match(/^(.+)_(gte|lte)$/);
+        if (!match) continue;
+        const attrKey = ATTRIBUTE_PARAM_ALIASES[match[1]];
+        if (!attrKey) continue; // unknown aliases already rejected upstream
+        const num = Number(value);
+        if (!Number.isFinite(num) || num < 0 || num > 99) {
+          return c.json(errorResponse(
+            `Invalid value for '${key}': expected a number between 0 and 99`,
+            "INVALID_PARAMETER"
+          ), 400);
+        }
+        const entry = attributeFilters.get(attrKey) ?? { key: attrKey };
+        entry[match[2] as "gte" | "lte"] = num;
+        attributeFilters.set(attrKey, entry);
+      }
+      if (attributeFilters.size > 0) {
+        queryArgs.attributeFilters = [...attributeFilters.values()];
+      }
+
+      // sort=<field>:<dir> where field is overall, name, or an attribute alias
+      if (params.sort) {
+        const [field, dirRaw] = params.sort.split(":");
+        const dir = dirRaw === "asc" ? "asc" : "desc";
+        if (field === "overall" || field === "name") {
+          queryArgs.sortBy = `${field}-${dir}`;
+        } else {
+          const attrKey = ATTRIBUTE_PARAM_ALIASES[field];
+          if (!attrKey) {
+            return c.json(errorResponse(
+              `Invalid sort field '${field}'. Use overall, name, or an attribute like three_ball, speed, driving_dunk, perimeter_defense.`,
+              "INVALID_PARAMETER"
+            ), 400);
+          }
+          queryArgs.sortByAttribute = { key: attrKey, dir };
+        }
+      }
 
       // Use optimized getAllFiltered which filters at database level
       const result = await c.env.runQuery(api.players.getAllFiltered, queryArgs);
+
+      // ?fields= projection (top-level fields only)
+      let players: any[] = result.players;
+      if (params.fields) {
+        const requested = params.fields.split(",").map((f: string) => f.trim()).filter(Boolean);
+        const unknown = requested.filter((f: string) => !PROJECTABLE_FIELDS.has(f));
+        if (unknown.length > 0) {
+          return c.json(errorResponse(
+            `Unknown field(s) in ?fields=: ${unknown.join(", ")}`,
+            "INVALID_PARAMETER",
+            { allowedFields: [...PROJECTABLE_FIELDS] }
+          ), 400);
+        }
+        players = players.map((p: any) =>
+          Object.fromEntries(requested.map((f: string) => [f, p[f]]))
+        );
+      }
 
       // Calculate next cursor
       const nextCursor = result.hasMore ? (offset + params.limit).toString() : undefined;
@@ -718,11 +801,11 @@ app.get("/api/players",
       // Add caching headers - player data cached for 1 hour
       c.header("Cache-Control", "public, max-age=3600");
 
-      return c.json(successResponse(result.players, {
+      return c.json(successResponse(players, {
         pagination: {
           hasMore: result.hasMore,
           nextCursor: nextCursor,
-          count: result.players.length,
+          count: players.length,
           limit: params.limit,
           total: result.totalCount,
         },

--- a/convex/players.ts
+++ b/convex/players.ts
@@ -720,6 +720,24 @@ export const getAllFiltered = query({
       v.literal("name-asc"),
       v.literal("name-desc")
     )),
+    // Range filters on players.attributes keys, e.g. { key: "threePointShot", gte: 85 }
+    attributeFilters: v.optional(
+      v.array(
+        v.object({
+          key: v.string(),
+          gte: v.optional(v.number()),
+          lte: v.optional(v.number()),
+        })
+      )
+    ),
+    // Sort by an attributes key; takes precedence over sortBy when present.
+    // Players missing the attribute sort last; ties break by overall desc.
+    sortByAttribute: v.optional(
+      v.object({
+        key: v.string(),
+        dir: v.union(v.literal("asc"), v.literal("desc")),
+      })
+    ),
     limit: v.optional(v.number()),
     offset: v.optional(v.number()),
   },
@@ -781,16 +799,43 @@ export const getAllFiltered = query({
       players = players.filter((p) => p.overall <= args.maxOverall!);
     }
 
+    // Filter by attribute ranges
+    if (args.attributeFilters && args.attributeFilters.length > 0) {
+      players = players.filter((p) =>
+        args.attributeFilters!.every((f) => {
+          const value = p.attributes?.[f.key];
+          if (value === undefined) return false;
+          if (f.gte !== undefined && value < f.gte) return false;
+          if (f.lte !== undefined && value > f.lte) return false;
+          return true;
+        })
+      );
+    }
+
     // Sort players
-    const sortBy = args.sortBy || "overall-desc";
-    if (sortBy === "overall-desc") {
-      players.sort((a, b) => b.overall - a.overall);
-    } else if (sortBy === "overall-asc") {
-      players.sort((a, b) => a.overall - b.overall);
-    } else if (sortBy === "name-asc") {
-      players.sort((a, b) => a.name.localeCompare(b.name));
-    } else if (sortBy === "name-desc") {
-      players.sort((a, b) => b.name.localeCompare(a.name));
+    if (args.sortByAttribute) {
+      const { key, dir } = args.sortByAttribute;
+      const sign = dir === "asc" ? 1 : -1;
+      players.sort((a, b) => {
+        const av = a.attributes?.[key];
+        const bv = b.attributes?.[key];
+        if (av === undefined && bv === undefined) return b.overall - a.overall;
+        if (av === undefined) return 1;
+        if (bv === undefined) return -1;
+        const d = sign * (av - bv);
+        return d !== 0 ? d : b.overall - a.overall;
+      });
+    } else {
+      const sortBy = args.sortBy || "overall-desc";
+      if (sortBy === "overall-desc") {
+        players.sort((a, b) => b.overall - a.overall);
+      } else if (sortBy === "overall-asc") {
+        players.sort((a, b) => a.overall - b.overall);
+      } else if (sortBy === "name-asc") {
+        players.sort((a, b) => a.name.localeCompare(b.name));
+      } else if (sortBy === "name-desc") {
+        players.sort((a, b) => b.name.localeCompare(a.name));
+      }
     }
 
     // Get total count before pagination
@@ -806,6 +851,31 @@ export const getAllFiltered = query({
       totalCount,
       hasMore: offset + limit < totalCount,
     };
+  },
+});
+
+/**
+ * Lightweight projection of every player for the Playground's client-side
+ * sentence-query engine: filtering/sorting happens in the browser, so this
+ * returns one slim row per player instead of full documents.
+ */
+export const getPlaygroundPlayers = query({
+  args: {},
+  handler: async (ctx) => {
+    const players = await ctx.db.query("players").collect();
+    return players.map((p) => ({
+      name: p.name,
+      slug: p.slug,
+      team: p.team,
+      teamType: p.teamType,
+      positions: p.positions ?? [],
+      overall: p.overall,
+      playerImage: p.playerImage ?? null,
+      threePointShot: p.attributes?.threePointShot ?? null,
+      speed: p.attributes?.speed ?? null,
+      drivingDunk: p.attributes?.drivingDunk ?? null,
+      perimeterDefense: p.attributes?.perimeterDefense ?? null,
+    }));
   },
 });
 


### PR DESCRIPTION
## What

Screen 2 of the reskin: **Final Playground.dc.html** rebuilt as the real `/playground`, plus the handoff README's "backend additions" so the request URLs the UI displays are all real, working API calls.

## Frontend

- Sentence-query composer: click any slot to cycle position group (guards/wings/bigs/anyone), era (any/current/classics), 3PT threshold (80/85/90/any), and sort (overall/three ball/speed/dunking/defense). The request URL, result table, and JSON rail update live.
- Result table: sortable headers with direction arrows, queried-column (3PT) highlight, tier-gradient OVR chips, era tags (CLASSIC/ALL-TIME in amber), position + short-team metas like "SG/SF · CHI '96" and "LAL A-T". Rows link to dossiers.
- Right rail: live JSON response preview, ?fields= tip, and three saved queries; the '96 Bulls one applies a team filter shown as a clearable chip.
- Export CSV and Copy JSON act on the full filtered result set.
- URL and sentence stay in sync using the real API param names, so playground links are shareable. Deep links keep unspecified slots wide open; only a pristine /playground gets the showcase defaults (guards, any era, 3PT >= 85).
- New shared pieces: `Headshot` (monogram fallback for stale 2kratings image URLs), `FooterStrip` (compact data-page footer), TopNav `wide` variant.

## Backend (from the handoff README)

`GET /api/players` gains, with legacy params untouched:
- `era=all|curr|class|allt` (all merges every era in one call)
- `position=guard|wing|big` groups alongside exact positions
- `<attr>_gte` / `<attr>_lte` for every attribute (snake_case + friendly aliases like `three_ball`)
- `sort=<field>:<asc|desc>` for overall, name, or any attribute
- `?fields=` payload trimming with strict validation

Convex: `getAllFiltered` gains `attributeFilters` + `sortByAttribute`; new slim `getPlaygroundPlayers` powers the client-side query engine (one fetch, instant slot cycling).

## Verified

- Build clean, tsc clean.
- Browser QA: slot cycling, header sorts, saved queries, deep-link behavior, no horizontal overflow at 390px.
- REST smoke test against the dev deployment: new params return correct data (231 guards with 3PT >= 85 across eras, Curry x3 on top), all error paths (bad sort, unknown param, bad fields) return helpful 400s, legacy calls unchanged. Throwaway QA key deactivated afterward.

## Notes

- The "128MS" latency chip from the mock is omitted (we don't fake numbers); the strip shows match count + cache policy.
- "+ ADD COLUMN" from the mock is deferred (dead UI until column config exists).
- Old playground filter components remain in place; `player-search-demo` and `team-roster` still import from them. Cleanup comes with the Teams/Dossier screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)