### PR TITLE
feat: teams board reskin — league ranked by roster strength

### DIFF
--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -346,7 +346,7 @@ function Playground() {
 
   return (
     <div className="min-h-screen bg-[#faf9f5] font-body text-[#1a1918]">
-      <TopNav hasApiKey={hasApiKey} wide />
+      <TopNav hasApiKey={hasApiKey} width="wide" />
 
       {/* Query card */}
       <div className="mx-auto max-w-[1440px] animate-[rise-in_400ms_cubic-bezier(0.23,1,0.32,1)_both] px-[clamp(20px,4vw,48px)] pt-2 motion-reduce:animate-none">
@@ -626,7 +626,7 @@ function Playground() {
         </div>
       </div>
 
-      <FooterStrip wide />
+      <FooterStrip width="wide" />
     </div>
   );
 }

--- a/app/teams/page.tsx
+++ b/app/teams/page.tsx
@@ -1,173 +1,234 @@
 "use client";
 
-import * as React from "react";
+import { Suspense, useEffect, useState } from "react";
+import Link from "next/link";
 import Image from "next/image";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
-import { motion } from "framer-motion";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { LoadingCard } from "@/components/ui/loading-card";
-import { fadeIn, staggerContainer, staggerItem } from "@/lib/animations";
+import { TopNav } from "@/components/chrome/top-nav";
+import { FooterStrip } from "@/components/chrome/footer-strip";
+import { Headshot } from "@/components/ui/headshot";
 import { getRatingClasses } from "@/lib/rating-colors";
-import { Users, Trophy, TrendingUp } from "lucide-react";
-import type { TeamType } from "@/types/player";
+import { getTeamAbbreviation, getTeamConference } from "@/lib/team-abbr";
+import { API_KEY_STORAGE_KEY } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
-export default function TeamsPage() {
-  const [teamType, setTeamType] = React.useState<TeamType>("curr");
+type TeamType = "curr" | "class" | "allt";
 
-  const teams = useQuery(api.teams.getAllTeams, { teamType });
+const ERA_TABS: { label: string; param: TeamType }[] = [
+  { label: "Current", param: "curr" },
+  { label: "Classic", param: "class" },
+  { label: "All-Time", param: "allt" },
+];
+
+/**
+ * Board display name: current teams keep their full name; classic
+ * "1995-96 Chicago Bulls" reads "'95-'96 Bulls"; all-time keeps
+ * "All-Time <nickname>".
+ */
+function boardName(team: string, teamType: TeamType): string {
+  if (teamType === "class") {
+    const m = team.match(/^\d{2}(\d{2})-(\d{2})\s+(.*)$/);
+    if (m) {
+      const nickname = m[3].split(" ").slice(-1)[0];
+      return `'${m[1]}-'${m[2]} ${nickname}`;
+    }
+  }
+  if (teamType === "allt") {
+    const nickname = team.replace(/^All-Time\s+/, "").split(" ").slice(-1)[0];
+    return `All-Time ${nickname}`;
+  }
+  return team;
+}
+
+function TeamLogo({ src, team }: { src: string | null; team: string }) {
+  const [errored, setErrored] = useState(false);
+  if (!src || errored) {
+    return (
+      <div className="flex h-[34px] w-[34px] items-center justify-center rounded-full bg-[#f1efe8] font-display text-[10px] font-extrabold text-[#57534a]">
+        {getTeamAbbreviation(team)}
+      </div>
+    );
+  }
+  return (
+    <div className="relative h-[34px] w-[34px]">
+      <Image
+        src={src}
+        alt={team}
+        fill
+        sizes="34px"
+        className="object-contain"
+        onError={() => setErrored(true)}
+      />
+    </div>
+  );
+}
+
+function Board() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const eraParam = searchParams.get("era");
+  const era: TeamType = ERA_TABS.some((t) => t.param === eraParam)
+    ? (eraParam as TeamType)
+    : "curr";
+  const [hasApiKey, setHasApiKey] = useState(false);
+
+  const board = useQuery(api.teams.getBoard, { teamType: era });
+
+  useEffect(() => {
+    setHasApiKey(!!localStorage.getItem(API_KEY_STORAGE_KEY));
+  }, []);
+
+  const setEra = (next: TeamType) =>
+    router.replace(next === "curr" ? "/teams" : `/teams?era=${next}`, { scroll: false });
+
+  // Bar widths normalized the way the design does: floor sits 1.5 below the
+  // weakest roster so the spread reads clearly.
+  const min = board && board.length ? Math.min(...board.map((t) => t.avgRating)) - 1.5 : 0;
+  const max = board && board.length ? Math.max(...board.map((t) => t.avgRating)) : 1;
+
+  const rowGrid =
+    "grid grid-cols-[56px_44px_minmax(160px,1.2fr)_60px_minmax(180px,1.6fr)_60px_minmax(170px,1fr)] items-center gap-3 px-[22px]";
 
   return (
-    <div className="container mx-auto max-w-7xl space-y-8 px-4 py-8">
-      {/* Header */}
-      <motion.div
-        variants={fadeIn}
-        initial="initial"
-        animate="animate"
-        className="space-y-2"
-      >
-        <h1 className="text-4xl font-bold tracking-tight">NBA 2K Teams</h1>
-        <p className="text-lg text-muted-foreground">
-          Browse teams from current NBA, classic, and all-time rosters
-        </p>
-      </motion.div>
+    <div className="min-h-screen bg-[#faf9f5] font-body text-[#1a1918]">
+      <TopNav hasApiKey={hasApiKey} width="narrow" />
 
-      {/* Team Type Filter */}
-      <motion.div
-        variants={fadeIn}
-        initial="initial"
-        animate="animate"
-        transition={{ delay: 0.1 }}
-      >
-        <Tabs value={teamType} onValueChange={(v) => setTeamType(v as TeamType)}>
-          <TabsList>
-            <TabsTrigger value="curr">Current Teams</TabsTrigger>
-            <TabsTrigger value="class">Classic Teams</TabsTrigger>
-            <TabsTrigger value="allt">All-Time Teams</TabsTrigger>
-          </TabsList>
-        </Tabs>
-      </motion.div>
-
-      {/* Teams Grid */}
-      {teams === undefined ? (
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {Array.from({ length: 9 }).map((_, i) => (
-            <LoadingCard key={i} variant="player" />
-          ))}
+      <div className="mx-auto max-w-[1280px] px-[clamp(20px,4vw,48px)] pt-3.5">
+        <div className="flex flex-wrap items-end justify-between gap-4 animate-[rise-in_400ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none">
+          <div>
+            <h1 className="m-0 font-display text-[clamp(30px,3.4vw,40px)] font-extrabold tracking-[-0.03em]">
+              The board
+            </h1>
+            <p className="mt-1.5 mb-0 font-plex text-[10px] tracking-[0.1em] text-[#8a8577]">
+              EVERY TEAM RANKED BY RATING STRENGTH — NOT STANDINGS
+            </p>
+          </div>
+          <div className="flex gap-[3px] rounded-full border border-[#e5e2da] bg-white p-1">
+            {ERA_TABS.map((t) => (
+              <button
+                key={t.param}
+                type="button"
+                onClick={() => setEra(t.param)}
+                className={cn(
+                  "cursor-pointer rounded-full px-4 py-[7px] text-[12.5px] font-semibold transition-[background,color,transform] duration-150 select-none active:scale-[0.97] motion-reduce:transition-none",
+                  era === t.param ? "bg-[#1a1918] text-[#faf9f5]" : "text-[#57534a] hover:bg-[#f1efe8]"
+                )}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
         </div>
-      ) : teams.length === 0 ? (
-        <motion.div
-          variants={fadeIn}
-          initial="initial"
-          animate="animate"
-          className="text-center py-12"
-        >
-          <p className="text-lg text-muted-foreground">
-            No teams found for this category
-          </p>
-        </motion.div>
-      ) : (
-        <motion.div
-          key={teamType}
-          variants={staggerContainer}
-          initial="initial"
-          animate="animate"
-          className="grid gap-6 md:grid-cols-2 lg:grid-cols-3"
-        >
-          {teams.map((team) => (
-            <motion.div key={`${team.name}-${team.type}`} variants={staggerItem}>
-              <a href={`/teams/${team.slug}?type=${team.type}`}>
-                <Card className="h-full transition-all hover:shadow-lg hover:border-primary/50 cursor-pointer">
-                  <CardHeader>
-                    <div className="flex items-start justify-between">
-                      <div className="flex items-center gap-3">
-                        {team.logo && (
-                          <div className="relative h-12 w-12 shrink-0">
-                            <Image
-                              src={team.logo}
-                              alt={team.name}
-                              fill
-                              className="rounded-lg object-contain"
-                            />
-                          </div>
-                        )}
-                        <div>
-                          <CardTitle className="text-xl">{team.name}</CardTitle>
-                          <p className="text-sm text-muted-foreground mt-1">
-                            {team.type === "curr"
-                              ? "Current"
-                              : team.type === "class"
-                              ? "Classic"
-                              : "All-Time"}
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-                  </CardHeader>
 
-                  <CardContent className="space-y-4">
-                    {/* Stats */}
-                    <div className="grid grid-cols-3 gap-4 text-center">
-                      <div className="space-y-1">
-                        <div className="flex items-center justify-center gap-1">
-                          <Users className="h-3 w-3 text-muted-foreground" />
-                          <p className="text-xs text-muted-foreground">Players</p>
-                        </div>
-                        <p className="text-lg font-bold">{team.playerCount}</p>
-                      </div>
+        <div
+          className="mt-5 overflow-hidden rounded-2xl border border-[#e5e2da] bg-white animate-[rise-in_400ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
+          style={{ animationDelay: "80ms" }}
+        >
+          <div className="overflow-x-auto">
+            <div className="min-w-[720px]">
+              <div className={cn(rowGrid, "border-b border-[#e5e2da] bg-[#faf9f5] py-[11px]")}>
+                <span className="font-plex text-[8.5px] tracking-[0.08em] text-[#b5b0a1]">RANK</span>
+                <span />
+                <span className="font-plex text-[8.5px] tracking-[0.08em] text-[#b5b0a1]">TEAM</span>
+                <span className="font-plex text-[8.5px] tracking-[0.08em] text-[#b5b0a1]">CONF</span>
+                <span className="font-plex text-[8.5px] tracking-[0.08em] text-[#b5b0a1]">
+                  ROSTER STRENGTH — AVG RATING OF FULL ROSTER
+                </span>
+                <span className="font-plex text-[8.5px] font-bold tracking-[0.08em] text-[#1a1918]">
+                  AVG ↓
+                </span>
+                <span className="font-plex text-[8.5px] tracking-[0.08em] text-[#b5b0a1]">
+                  BEST PLAYER
+                </span>
+              </div>
 
-                      <div className="space-y-1">
-                        <div className="flex items-center justify-center gap-1">
-                          <TrendingUp className="h-3 w-3 text-muted-foreground" />
-                          <p className="text-xs text-muted-foreground">Avg Rating</p>
-                        </div>
+              {board
+                ? board.map((t, i) => (
+                    <Link
+                      key={t.team}
+                      href={`/teams/${t.slug}?type=${era}`}
+                      className={cn(
+                        rowGrid,
+                        "border-b border-[#f6f4ee] py-2.5 text-[#1a1918] no-underline transition-colors duration-100 animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] hover:bg-[#faf8f2] active:scale-[0.995] motion-reduce:animate-none"
+                      )}
+                      style={{ animationDelay: `${Math.min(i, 20) * 30}ms` }}
+                    >
+                      <span className="font-display text-[19px] font-extrabold text-[#b5b0a1]">
+                        {i + 1}
+                      </span>
+                      <TeamLogo src={t.logo} team={t.team} />
+                      <span className="overflow-hidden text-[14.5px] font-semibold text-ellipsis whitespace-nowrap">
+                        {boardName(t.team, era)}
+                      </span>
+                      <span className="font-plex text-[9px] text-[#b5b0a1]">
+                        {getTeamConference(t.team) ?? "—"}
+                      </span>
+                      <div className="h-2 rounded-full bg-[#f1efe8]">
                         <div
+                          className="h-full rounded-full bg-[linear-gradient(to_right,#8a8577,#1a1918)] transition-[width] duration-400"
+                          style={{
+                            width: `${Math.round(((t.avgRating - min) / (max - min)) * 100)}%`,
+                          }}
+                        />
+                      </div>
+                      <span className="font-plex text-[13px] font-bold tabular-nums">
+                        {t.avgRating.toFixed(1)}
+                      </span>
+                      <div className="flex min-w-0 items-center gap-2">
+                        <Headshot
+                          src={t.bestPlayer.playerImage}
+                          name={t.bestPlayer.name}
+                          size={26}
+                        />
+                        <span className="flex-1 overflow-hidden text-[12px] font-semibold text-ellipsis whitespace-nowrap">
+                          {t.bestPlayer.name}
+                        </span>
+                        <span
                           className={cn(
-                            "inline-flex items-center justify-center px-2 py-0.5 rounded-sm",
-                            getRatingClasses(team.avgRating).bg,
-                            getRatingClasses(team.avgRating).shadow
+                            "inline-flex min-w-[30px] items-center justify-center rounded-[5px] px-1 py-0.5 text-[11px] font-bold text-white tabular-nums",
+                            getRatingClasses(t.bestPlayer.overall).bg
                           )}
                         >
-                          <span className="text-lg font-bold tabular-nums text-white">
-                            {team.avgRating}
-                          </span>
-                        </div>
+                          {t.bestPlayer.overall}
+                        </span>
                       </div>
-
-                      <div className="space-y-1">
-                        <div className="flex items-center justify-center gap-1">
-                          <Trophy className="h-3 w-3 text-muted-foreground" />
-                          <p className="text-xs text-muted-foreground">Top Player</p>
-                        </div>
-                        <div
-                          className={cn(
-                            "inline-flex items-center justify-center px-2 py-0.5 rounded-sm",
-                            getRatingClasses(team.topPlayerOverall).bg,
-                            getRatingClasses(team.topPlayerOverall).shadow
-                          )}
-                        >
-                          <span className="text-lg font-bold tabular-nums text-white">
-                            {team.topPlayerOverall}
-                          </span>
-                        </div>
-                      </div>
+                    </Link>
+                  ))
+                : Array.from({ length: 12 }, (_, i) => (
+                    <div key={i} className={cn(rowGrid, "animate-pulse border-b border-[#f6f4ee] py-2.5")}>
+                      <span className="h-5 w-6 rounded bg-[#f1efe8]" />
+                      <div className="h-[34px] w-[34px] rounded-full bg-[#f1efe8]" />
+                      <span className="h-3.5 w-3/4 rounded bg-[#f1efe8]" />
+                      <span className="h-3 w-8 rounded bg-[#f1efe8]" />
+                      <span className="h-2 rounded-full bg-[#f1efe8]" />
+                      <span className="h-3.5 w-9 rounded bg-[#f1efe8]" />
+                      <span className="h-[26px] w-2/3 rounded-full bg-[#f1efe8]" />
                     </div>
+                  ))}
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-2 bg-[#faf9f5] px-[22px] py-2.5">
+            <span className="font-plex text-[8.5px] text-[#b5b0a1]">
+              CLICK A TEAM → DEPTH CHART · ← → CYCLES TEAMS FROM ANY TEAM PAGE
+            </span>
+            <span className="font-plex text-[8.5px] text-[#b5b0a1]">GET /api/teams?era={era}</span>
+          </div>
+        </div>
+      </div>
 
-                    {/* View Team Button */}
-                    <Button className="w-full" variant="outline">
-                      View Roster
-                    </Button>
-                  </CardContent>
-                </Card>
-              </a>
-            </motion.div>
-          ))}
-        </motion.div>
-      )}
+      <div className="mt-12">
+        <FooterStrip width="narrow" />
+      </div>
     </div>
+  );
+}
+
+export default function TeamsPage() {
+  return (
+    <Suspense fallback={null}>
+      <Board />
+    </Suspense>
   );
 }

--- a/components/chrome/footer-strip.tsx
+++ b/components/chrome/footer-strip.tsx
@@ -1,17 +1,18 @@
 import Link from "next/link";
 import { cn } from "@/lib/utils";
+import { SHELL_WIDTHS } from "@/components/chrome/top-nav";
 
 /**
  * Compact one-line footer used by data-dense reskinned pages (Playground,
  * Board, Whiteboard). Marketing-weight pages use SiteFooter instead.
  */
-export function FooterStrip({ wide = false }: { wide?: boolean }) {
+export function FooterStrip({ width = "default" }: { width?: keyof typeof SHELL_WIDTHS }) {
   return (
     <div className="border-t border-[#e5e2da] bg-[#f5f3ec]">
       <div
         className={cn(
           "mx-auto flex flex-wrap items-center justify-between gap-2.5 px-[clamp(20px,4vw,48px)] py-[18px] font-plex text-[11px] text-[#8a8577]",
-          wide ? "max-w-[1440px]" : "max-w-[1360px]"
+          SHELL_WIDTHS[width]
         )}
       >
         <span className="font-display text-[15px] font-extrabold text-[#1a1918]">nba2kapi</span>

--- a/components/chrome/top-nav.tsx
+++ b/components/chrome/top-nav.tsx
@@ -58,15 +58,21 @@ type TopNavProps = {
   onCtaClick?: () => void;
   /** Swaps the CTA label for returning users who already hold a key. */
   hasApiKey?: boolean;
-  /** Data-dense pages (Playground, Board, Whiteboard) run a 1440px shell. */
-  wide?: boolean;
+  /** Page shell width: narrow 1280 (Board), default 1360, wide 1440 (Playground). */
+  width?: "narrow" | "default" | "wide";
 };
+
+export const SHELL_WIDTHS = {
+  narrow: "max-w-[1280px]",
+  default: "max-w-[1360px]",
+  wide: "max-w-[1440px]",
+} as const;
 
 /**
  * Shared chrome for reskinned (paper/editorial) pages: wordmark, pill nav,
  * search pill, GitHub star chip, and the primary API-key CTA.
  */
-export function TopNav({ onCtaClick, hasApiKey = false, wide = false }: TopNavProps) {
+export function TopNav({ onCtaClick, hasApiKey = false, width = "default" }: TopNavProps) {
   const ctaLabel = hasApiKey ? "View dashboard" : "Get an API key";
   const pathname = usePathname();
   const router = useRouter();
@@ -97,7 +103,7 @@ export function TopNav({ onCtaClick, hasApiKey = false, wide = false }: TopNavPr
     <div
       className={cn(
         "mx-auto flex w-full flex-wrap items-center justify-between gap-3 px-[clamp(20px,4vw,48px)] py-5",
-        wide ? "max-w-[1440px]" : "max-w-[1360px]"
+        SHELL_WIDTHS[width]
       )}
     >
       <Link

--- a/components/legacy-chrome.tsx
+++ b/components/legacy-chrome.tsx
@@ -7,7 +7,7 @@ import { Footer } from "@/components/footer";
 // Routes that have been migrated to the new (paper/editorial) design render
 // their own chrome (TopNav / SiteFooter) inside the page, so the legacy
 // header/footer must not double up on them.
-const RESKINNED_ROUTES = new Set(["/", "/playground"]);
+const RESKINNED_ROUTES = new Set(["/", "/playground", "/teams"]);
 
 export function LegacyHeader() {
   const pathname = usePathname();

--- a/convex/_validation.ts
+++ b/convex/_validation.ts
@@ -237,7 +237,7 @@ export const VALID_PARAMS_BY_ENDPOINT: Record<string, Set<string>> = {
   "/api/players/:id/attribute/:attr": new Set(["limit"]),
   "/api/players/:id/versions": new Set([]),
   "/api/players/slug/:slug": new Set(["teamType", "team"]),
-  "/api/teams": new Set(["teamType"]),
+  "/api/teams": new Set(["teamType", "era"]),
   "/api/teams/:teamName/roster": new Set(["teamType"]),
   "/api/trending": new Set(["teamType", "days", "limit"]),
   "/api/badges": new Set(["category", "gameVersion"]),

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1210,10 +1210,13 @@ app.get("/api/teams",
   rejectUnknownParams("/api/teams"),
   zValidator("query", z.object({
     teamType: z.enum(["curr", "class", "allt"]).default("curr"),
+    // era is an alias for teamType (matches /api/players naming)
+    era: z.enum(["curr", "class", "allt"]).optional(),
   })),
   async (c) => {
     try {
-      const { teamType } = c.req.valid("query");
+      const params = c.req.valid("query");
+      const teamType = params.era ?? params.teamType;
 
       const teams = await c.env.runQuery(api.players.getTeams, { teamType });
 

--- a/convex/teams.ts
+++ b/convex/teams.ts
@@ -40,6 +40,58 @@ export const getTeamBySlug = query({
 });
 
 /**
+ * The Board: every team of an era ranked by average roster rating, with the
+ * best player attached. One row per team, slim payload.
+ */
+export const getBoard = query({
+  args: {
+    teamType: v.union(v.literal("curr"), v.literal("class"), v.literal("allt")),
+  },
+  handler: async (ctx, args) => {
+    const players = await ctx.db
+      .query("players")
+      .withIndex("by_teamType", (q) => q.eq("teamType", args.teamType))
+      .collect();
+
+    type Agg = {
+      team: string;
+      logo: string | null;
+      count: number;
+      sum: number;
+      best: (typeof players)[number];
+    };
+    const byTeam = new Map<string, Agg>();
+    for (const p of players) {
+      let agg = byTeam.get(p.team);
+      if (!agg) {
+        agg = { team: p.team, logo: p.teamImg ?? null, count: 0, sum: 0, best: p };
+        byTeam.set(p.team, agg);
+      }
+      agg.count++;
+      agg.sum += p.overall;
+      if (!agg.logo && p.teamImg) agg.logo = p.teamImg;
+      if (p.overall > agg.best.overall) agg.best = p;
+    }
+
+    return [...byTeam.values()]
+      .map((t) => ({
+        team: t.team,
+        slug: t.team.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+        logo: t.logo,
+        playerCount: t.count,
+        avgRating: Math.round((t.sum / t.count) * 10) / 10,
+        bestPlayer: {
+          name: t.best.name,
+          slug: t.best.slug,
+          overall: t.best.overall,
+          playerImage: t.best.playerImage ?? null,
+        },
+      }))
+      .sort((a, b) => b.avgRating - a.avgRating || a.team.localeCompare(b.team));
+  },
+});
+
+/**
  * Get detailed team statistics
  */
 export const getTeamStats = query({

--- a/lib/team-abbr.ts
+++ b/lib/team-abbr.ts
@@ -34,6 +34,14 @@ export const TEAM_ABBREVIATIONS: Record<string, string> = {
   "Toronto Raptors": "TOR",
   "Utah Jazz": "UTA",
   "Washington Wizards": "WAS",
+  // Historical franchise names that appear in classic-era rosters
+  "Seattle SuperSonics": "SEA",
+  "Seattle Supersonics": "SEA",
+  "New Jersey Nets": "NJN",
+  "Vancouver Grizzlies": "VAN",
+  "Washington Bullets": "WAS",
+  "Charlotte Bobcats": "CHA",
+  "New Orleans Hornets": "NOH",
 };
 
 /** Franchise → conference. Same includes-matching as abbreviations. */
@@ -69,6 +77,14 @@ export const TEAM_CONFERENCES: Record<string, "EAST" | "WEST"> = {
   "Toronto Raptors": "EAST",
   "Utah Jazz": "WEST",
   "Washington Wizards": "EAST",
+  // Historical franchise names that appear in classic-era rosters
+  "Seattle SuperSonics": "WEST",
+  "Seattle Supersonics": "WEST",
+  "New Jersey Nets": "EAST",
+  "Vancouver Grizzlies": "WEST",
+  "Washington Bullets": "EAST",
+  "Charlotte Bobcats": "EAST",
+  "New Orleans Hornets": "WEST",
 };
 
 /**

--- a/lib/team-abbr.ts
+++ b/lib/team-abbr.ts
@@ -36,6 +36,54 @@ export const TEAM_ABBREVIATIONS: Record<string, string> = {
   "Washington Wizards": "WAS",
 };
 
+/** Franchise → conference. Same includes-matching as abbreviations. */
+export const TEAM_CONFERENCES: Record<string, "EAST" | "WEST"> = {
+  "Atlanta Hawks": "EAST",
+  "Boston Celtics": "EAST",
+  "Brooklyn Nets": "EAST",
+  "Charlotte Hornets": "EAST",
+  "Chicago Bulls": "EAST",
+  "Cleveland Cavaliers": "EAST",
+  "Dallas Mavericks": "WEST",
+  "Denver Nuggets": "WEST",
+  "Detroit Pistons": "EAST",
+  "Golden State Warriors": "WEST",
+  "Houston Rockets": "WEST",
+  "Indiana Pacers": "EAST",
+  "LA Clippers": "WEST",
+  "Los Angeles Clippers": "WEST",
+  "Los Angeles Lakers": "WEST",
+  "Memphis Grizzlies": "WEST",
+  "Miami Heat": "EAST",
+  "Milwaukee Bucks": "EAST",
+  "Minnesota Timberwolves": "WEST",
+  "New Orleans Pelicans": "WEST",
+  "New York Knicks": "EAST",
+  "Oklahoma City Thunder": "WEST",
+  "Orlando Magic": "EAST",
+  "Philadelphia 76ers": "EAST",
+  "Phoenix Suns": "WEST",
+  "Portland Trail Blazers": "WEST",
+  "Sacramento Kings": "WEST",
+  "San Antonio Spurs": "WEST",
+  "Toronto Raptors": "EAST",
+  "Utah Jazz": "WEST",
+  "Washington Wizards": "EAST",
+};
+
+/**
+ * Conference for any team name variant (classic/all-time included).
+ * Historical relocations aside, this maps by the modern franchise name;
+ * unknown names return null.
+ */
+export function getTeamConference(team: string): "EAST" | "WEST" | null {
+  if (TEAM_CONFERENCES[team]) return TEAM_CONFERENCES[team];
+  for (const [name, conf] of Object.entries(TEAM_CONFERENCES)) {
+    if (team.includes(name)) return conf;
+  }
+  return null;
+}
+
 /**
  * Abbreviate any team name, including classic ("'96 Chicago Bulls") and
  * all-time ("All-Time Chicago Bulls") variants, by matching the modern

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,11 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   turbopack: {},
   images: {
+    // Team logos are 2kratings SVGs served through the optimizer (2kratings
+    // blocks hotlinking). Sandboxed CSP + attachment disposition per Next docs.
+    dangerouslyAllowSVG: true,
+    contentDispositionType: "attachment",
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
## What

Screen 3: **Final Teams.dc.html** as the real `/teams`. One league-wide table ranked by average roster rating (explicitly not standings), with era tabs that swap the dataset and sync to the URL.

## How

- New `convex/teams.getBoard` aggregates each era server-side: avg rating (one decimal), player count, logo, and best player per team. 30 current / 66 classic / 30 all-time rows, all live.
- Roster-strength bars normalize against the era's own spread (floor 1.5 below the weakest roster, like the mock) so differences read clearly.
- Conference comes from a new franchise map (`getTeamConference`), rendered as the deliberately demoted small tag; classic and all-time names compress to "'95-'96 Bulls" / "All-Time Bulls".
- Team logos are 2kratings SVGs, so the image optimizer now allows SVG with the standard sandboxed CSP + attachment disposition. This also fixes the legacy teams page's logo path.
- Rows link into the existing team pages (reskin of those is the next PR). `/api/teams` accepts `era` as an alias so the footer hint is a real call.
- TopNav/FooterStrip gained a shell-width prop (board runs the design's 1280px shell).

## Verified

- Build + tsc clean; Convex pushed to dev.
- Browser QA: all three era tabs with live data, URL sync, logos + headshots rendering (monogram fallback for two stale upstream images), rows navigate to team pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)