### PR TITLE
feat: dashboard reskin — key card, usage, request log, two-step key dialog

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -86,6 +86,17 @@ export default function DashboardPage() {
     return () => clearInterval(tick);
   }, []);
 
+  // A stale key (deleted or regenerated in another browser) resolves to null:
+  // drop it and fall back to the signup state.
+  useEffect(() => {
+    if (apiKey && stats === null) {
+      localStorage.removeItem(API_KEY_STORAGE_KEY);
+      setApiKey(null);
+      setShowDialog(true);
+      toast("That key is no longer active — create a fresh one.");
+    }
+  }, [apiKey, stats]);
+
   const resetsInMin = useMemo(() => {
     if (!stats?.resetAt) return null;
     return Math.max(0, Math.ceil((new Date(stats.resetAt).getTime() - now) / 60000));

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,621 +1,353 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useQuery, useMutation } from "convex/react";
-import { api } from "../../convex/_generated/api";
-import { ApiKeyDisplay } from "@/components/api-key-display";
-import { RegistrationDialog } from "@/components/registration-dialog";
-import { QuickActionCard } from "@/components/quick-action-card";
-import { Button } from "@/components/ui/button";
-import { GameCard } from "@/components/ui/game-card";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Progress } from "@/components/ui/progress";
-import { Skeleton } from "@/components/ui/skeleton";
-import { Badge } from "@/components/ui/badge";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import {
-  Activity,
-  AlertCircle,
-  BookOpen,
-  Code2,
-  Copy,
-  Github,
-  Loader2,
-  Play,
-  Rocket,
-  TrendingUp,
-  SlidersHorizontal,
-  Terminal,
-  Users,
-  ExternalLink,
-} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { API_KEY_STORAGE_KEY, CONVEX_SITE_URL } from "@/lib/constants";
-import { parseEndpointToDeepLink } from "@/lib/deep-link-parser";
+import { useMutation, useQuery } from "convex/react";
+import { Copy, Eye } from "lucide-react";
+import { toast } from "sonner";
+import { api } from "@/convex/_generated/api";
+import { TopNav } from "@/components/chrome/top-nav";
+import { FooterStrip } from "@/components/chrome/footer-strip";
+import { KeyDialog } from "@/components/chrome/key-dialog";
+import { API_KEY_STORAGE_KEY } from "@/lib/constants";
+import { cn } from "@/lib/utils";
+
+const CARD_LABEL = "font-plex text-[9px] tracking-[0.1em] text-[#8a8577]";
+
+function maskKey(key: string) {
+  return `2k_••••${key.slice(-4)}`;
+}
+
+function timeAgo(iso: string) {
+  const mins = Math.floor((Date.now() - new Date(iso).getTime()) / 60000);
+  if (mins < 1) return "NOW";
+  if (mins < 60) return `${mins}M AGO`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}H AGO`;
+  return `${Math.floor(hours / 24)}D AGO`;
+}
+
+function formatDate(iso: string) {
+  return new Date(iso)
+    .toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
+    .toUpperCase();
+}
+
+function statusColor(code: number) {
+  if (code >= 200 && code < 300) return "#0a7f3f";
+  if (code === 429) return "#9a6700";
+  if (code >= 400) return "#c03a2b";
+  return "#8a8577";
+}
+
+/** Map an API endpoint back into the product surface that shows the same data. */
+function deepLink(endpoint: string): { href: string; label: string } | null {
+  const [path, query] = endpoint.split("?");
+  const slugMatch = path.match(/^\/api\/players\/slug\/([a-z0-9-]+)/);
+  if (slugMatch) return { href: `/players/${slugMatch[1]}`, label: "→ DOSSIER" };
+  const rosterMatch = path.match(/^\/api\/teams\/([^/]+)\/roster/);
+  if (rosterMatch) {
+    const slug = decodeURIComponent(rosterMatch[1]).toLowerCase().replace(/[^a-z0-9]+/g, "-");
+    return { href: `/teams/${slug}`, label: "→ TEAM" };
+  }
+  if (path === "/api/teams") return { href: "/teams", label: "→ BOARD" };
+  if (path.startsWith("/api/players")) {
+    const passthrough = new URLSearchParams();
+    if (query) {
+      const params = new URLSearchParams(query);
+      for (const k of ["position", "era", "three_ball_gte", "sort", "team"]) {
+        const v = params.get(k);
+        if (v) passthrough.set(k, v);
+      }
+    }
+    const qs = passthrough.toString();
+    return { href: qs ? `/playground?${qs}` : "/playground", label: "→ PLAYGROUND" };
+  }
+  return null;
+}
 
 export default function DashboardPage() {
   const [apiKey, setApiKey] = useState<string | null>(null);
-  const [showRegistration, setShowRegistration] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
-  const [onboardingCopied, setOnboardingCopied] = useState(false);
-  const [onboardingDemoResult, setOnboardingDemoResult] = useState<any>(null);
-  const [onboardingDemoLoading, setOnboardingDemoLoading] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const [showDialog, setShowDialog] = useState(false);
+  const [reveal, setReveal] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
 
   const regenerateApiKey = useMutation(api.apiKeys.regenerateApiKey);
-
-  const API_BASE = CONVEX_SITE_URL;
-
-  const getOnboardingCurlCommand = (key: string) =>
-    `curl -H "X-API-Key: ${key}" ${API_BASE}/api/players?minRating=95`;
-
-  const copyOnboardingCommand = async () => {
-    if (!apiKey) return;
-    await navigator.clipboard.writeText(getOnboardingCurlCommand(apiKey));
-    setOnboardingCopied(true);
-    setTimeout(() => setOnboardingCopied(false), 2000);
-  };
-
-  const runOnboardingDemo = async () => {
-    if (!apiKey) return;
-    setOnboardingDemoLoading(true);
-    setOnboardingDemoResult(null);
-
-    try {
-      const response = await fetch(`${API_BASE}/api/players?minRating=95&limit=3`, {
-        headers: { "X-API-Key": apiKey }
-      });
-      const data = await response.json();
-      setOnboardingDemoResult(data);
-    } catch (err) {
-      setOnboardingDemoResult({ success: false, error: { message: "Failed to make request" } });
-    } finally {
-      setOnboardingDemoLoading(false);
-    }
-  };
-
-  // Get stats using the API key
-  const stats = useQuery(
-    api.apiKeys.getApiKeyStats,
-    apiKey ? { key: apiKey } : "skip"
-  );
+  const stats = useQuery(api.apiKeys.getApiKeyStats, apiKey ? { key: apiKey } : "skip");
 
   useEffect(() => {
-    setIsMounted(true);
-    // Check for API key in localStorage
-    const storedKey = localStorage.getItem(API_KEY_STORAGE_KEY);
-    if (storedKey) {
-      setApiKey(storedKey);
-    } else {
-      setShowRegistration(true);
-    }
+    setMounted(true);
+    const stored = localStorage.getItem(API_KEY_STORAGE_KEY);
+    if (stored) setApiKey(stored);
+    else setShowDialog(true);
+    const tick = setInterval(() => setNow(Date.now()), 30000);
+    return () => clearInterval(tick);
   }, []);
 
-  const handleRegistrationSuccess = (newApiKey: string) => {
-    setApiKey(newApiKey);
-    setShowRegistration(false);
+  const resetsInMin = useMemo(() => {
+    if (!stats?.resetAt) return null;
+    return Math.max(0, Math.ceil((new Date(stats.resetAt).getTime() - now) / 60000));
+  }, [stats?.resetAt, now]);
+
+  const copyKey = () => {
+    if (!apiKey) return;
+    navigator.clipboard.writeText(apiKey).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1400);
+    });
+  };
+
+  const copyCurl = () => {
+    if (!apiKey) return;
+    navigator.clipboard
+      .writeText(`curl -H "X-API-Key: ${apiKey}" https://api.nba2kapi.com/api/players?minRating=95`)
+      .then(() => toast.success("curl command copied"));
   };
 
   const handleRegenerate = async () => {
     if (!apiKey) return;
-
-    const result = await regenerateApiKey({ oldKey: apiKey });
-    const newKey = result.apiKey;
-
-    // Update localStorage
-    localStorage.setItem(API_KEY_STORAGE_KEY, newKey);
-    setApiKey(newKey);
-  };
-
-  const getStatusColor = (statusCode: number): "default" | "secondary" | "destructive" | "outline" => {
-    if (statusCode >= 200 && statusCode < 300) return "default";
-    if (statusCode >= 400 && statusCode < 500) return "outline";
-    if (statusCode >= 500) return "destructive";
-    return "secondary";
-  };
-
-  const getMethodColor = (method: string): "default" | "secondary" | "destructive" | "outline" => {
-    switch (method.toUpperCase()) {
-      case "GET":
-        return "default";
-      case "POST":
-        return "secondary";
-      case "PUT":
-      case "PATCH":
-        return "outline";
-      case "DELETE":
-        return "destructive";
-      default:
-        return "secondary";
+    if (!window.confirm("Regenerate your key? The current key stops working immediately.")) return;
+    try {
+      const result = await regenerateApiKey({ oldKey: apiKey });
+      localStorage.setItem(API_KEY_STORAGE_KEY, result.apiKey);
+      setApiKey(result.apiKey);
+      setReveal(true);
+      toast.success("New key issued — the old one is dead. It's revealed above; copy it now.");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Could not regenerate the key");
     }
   };
 
-  const formatTimestamp = (timestamp: string) => {
-    const date = new Date(timestamp);
-    const now = new Date();
-    const diff = now.getTime() - date.getTime();
-    const seconds = Math.floor(diff / 1000);
-    const minutes = Math.floor(seconds / 60);
-    const hours = Math.floor(minutes / 60);
-    const days = Math.floor(hours / 24);
-
-    if (days > 0) return `${days}d ago`;
-    if (hours > 0) return `${hours}h ago`;
-    if (minutes > 0) return `${minutes}m ago`;
-    return `${seconds}s ago`;
-  };
-
-  const calculateTimeUntilReset = (resetAt: string) => {
-    const reset = new Date(resetAt);
-    const now = new Date();
-    const diff = reset.getTime() - now.getTime();
-    const minutes = Math.floor(diff / 1000 / 60);
-
-    if (minutes < 1) return "< 1 minute";
-    if (minutes === 1) return "1 minute";
-    return `${minutes} minutes`;
-  };
-
-  // Don't render until mounted to avoid hydration issues
-  if (!isMounted) {
-    return (
-      <div className="container mx-auto px-4 py-8">
-        <div className="space-y-6">
-          <Skeleton className="h-12 w-64" />
-          <Skeleton className="h-48" />
-          <Skeleton className="h-32" />
-        </div>
-      </div>
-    );
-  }
-
-  if (!apiKey) {
-    return (
-      <>
-        <div className="container mx-auto flex min-h-[60vh] items-center justify-center px-4 py-8">
-          <div className="text-center">
-            <h1 className="mb-4 text-3xl font-bold">Welcome to NBA 2K API</h1>
-            <p className="mb-6 text-slate-600 dark:text-slate-400">
-              Create a free API key to get started
-            </p>
-            <Button onClick={() => setShowRegistration(true)} size="lg">
-              Get Your API Key
-            </Button>
-          </div>
-        </div>
-
-        <RegistrationDialog
-          open={showRegistration}
-          onOpenChange={setShowRegistration}
-          onSuccess={handleRegistrationSuccess}
-        />
-      </>
-    );
-  }
-
-  // Show loading state while fetching stats
-  if (apiKey && (!stats || !stats.apiKey)) {
-    return (
-      <div className="container mx-auto px-4 py-8">
-        <div className="space-y-6">
-          <div>
-            <Skeleton className="mb-2 h-10 w-64" />
-            <Skeleton className="h-6 w-96" />
-          </div>
-          <Skeleton className="h-48" />
-          <div className="grid gap-6 md:grid-cols-3">
-            <Skeleton className="h-32" />
-            <Skeleton className="h-32" />
-            <Skeleton className="h-32" />
-          </div>
-          <Skeleton className="h-64" />
-        </div>
-      </div>
-    );
-  }
-
-  // If we have an API key but no stats, something went wrong
-  if (apiKey && stats === undefined) {
-    return (
-      <div className="container mx-auto px-4 py-8">
-        <Alert variant="destructive">
-          <AlertCircle className="h-4 w-4" />
-          <AlertDescription>
-            Failed to load dashboard data. Please check your API key or try refreshing the page.
-          </AlertDescription>
-        </Alert>
-      </div>
-    );
-  }
-
-  // TypeScript guard: stats is guaranteed to be defined here
-  if (!stats) {
-    return null;
-  }
-
-  const progressPercentage = Math.min(
-    100,
-    (stats.requestCount / stats.rateLimit) * 100
-  );
+  const usagePct = stats ? Math.min(100, Math.round((stats.requestCount / stats.rateLimit) * 100)) : 0;
 
   return (
-    <>
-      <div className="container mx-auto px-4 py-8">
-        <div className="mb-8">
-          <h1 className="mb-2 text-4xl font-bold font-rajdhani tracking-tight">API Dashboard</h1>
-          <p className="text-slate-600 dark:text-slate-400 font-rajdhani tracking-wide text-lg">
-            Try the playground to explore data visually, then use the API to integrate into your application
-          </p>
+    <div className="min-h-screen bg-[#faf9f5] font-body text-[#1a1918]">
+      <TopNav
+        hasApiKey={!!apiKey}
+        maskedKey={mounted && apiKey ? maskKey(apiKey) : null}
+        width="narrow"
+      />
+
+      <div className="mx-auto max-w-[1280px] px-[clamp(20px,4vw,48px)] pt-2">
+        {/* Header */}
+        <div className="flex flex-wrap items-baseline justify-between gap-3 animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none">
+          <div>
+            <h1 className="m-0 font-display text-[clamp(28px,3.2vw,36px)] font-extrabold tracking-[-0.03em]">
+              Dashboard
+            </h1>
+            <p className="mt-1.5 mb-0 font-plex text-[9.5px] tracking-[0.1em] text-[#8a8577]">
+              {stats
+                ? `KEY CREATED ${formatDate(stats.apiKey.createdAt)} · FREE TIER · ${stats.rateLimit} REQ/HR`
+                : apiKey
+                  ? "LOADING KEY…"
+                  : "NO KEY IN THIS BROWSER YET"}
+            </p>
+          </div>
+          {apiKey && (
+            <button
+              type="button"
+              onClick={handleRegenerate}
+              className="cursor-pointer font-plex text-[9.5px] tracking-[0.06em] text-[#c03a2b] hover:underline"
+            >
+              ↻ REGENERATE KEY
+            </button>
+          )}
         </div>
 
-        {/* First-time User Onboarding */}
-        {stats.totalRequests === 0 && (
-          <Card className="mb-6 border-2 border-primary bg-gradient-to-br from-primary/5 to-primary/10">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2 font-rajdhani text-2xl">
-                <Rocket className="h-6 w-6 text-primary" />
-                Welcome! Make your first API call
-              </CardTitle>
-              <CardDescription>
-                Your API key is ready. Try it out with one of these options:
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="grid gap-4 md:grid-cols-3">
-                {/* Terminal Option */}
-                <Card className="bg-white/50 dark:bg-white/5">
-                  <CardContent className="p-4 space-y-3">
-                    <div className="flex items-center gap-2">
-                      <Terminal className="h-5 w-5 text-primary" />
-                      <h4 className="font-semibold">Terminal</h4>
-                    </div>
-                    <div className="rounded-lg bg-slate-950 p-2 overflow-x-auto">
-                      <code className="text-xs text-green-400 whitespace-pre-wrap break-all">
-                        {getOnboardingCurlCommand(apiKey)}
-                      </code>
-                    </div>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={copyOnboardingCommand}
-                      className="w-full"
+        {!mounted || (!apiKey && !showDialog) ? null : !apiKey ? (
+          <div className="mt-16 mb-24 text-center">
+            <h2 className="m-0 font-display text-[24px] font-extrabold tracking-[-0.02em]">
+              The key is the login
+            </h2>
+            <p className="mx-auto mt-2 mb-6 max-w-[380px] text-[13.5px] leading-[1.6] text-[#57534a]">
+              No account, no password. Create a free key and this browser becomes your dashboard.
+            </p>
+            <button
+              type="button"
+              onClick={() => setShowDialog(true)}
+              className="cursor-pointer rounded-full bg-[#1a1918] px-7 py-3.5 text-[15px] font-semibold text-[#faf9f5] transition-[background,transform] duration-150 hover:bg-[#333] active:scale-[0.97] motion-reduce:transition-none"
+            >
+              Get an API key
+            </button>
+          </div>
+        ) : (
+          <>
+            {/* Cards */}
+            <div
+              className="mt-[18px] grid grid-cols-[repeat(auto-fit,minmax(min(100%,260px),1fr))] gap-3 animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
+              style={{ animationDelay: "60ms" }}
+            >
+              <div className="flex min-w-0 flex-col justify-between rounded-[14px] bg-[#1a1918] px-[18px] py-4">
+                <div className="flex items-center justify-between">
+                  <span className="font-plex text-[9px] tracking-[0.1em] text-white/60">
+                    YOUR API KEY
+                  </span>
+                  <div className="flex gap-3">
+                    <button
+                      type="button"
+                      onClick={() => setReveal((r) => !r)}
+                      title={reveal ? "Mask the key" : "Reveal the key"}
+                      className="cursor-pointer text-white/70 transition-colors duration-150 hover:text-white"
                     >
-                      <Copy className="h-3 w-3 mr-1" />
-                      {onboardingCopied ? "Copied!" : "Copy Command"}
-                    </Button>
-                  </CardContent>
-                </Card>
-
-                {/* Playground Option */}
-                <Card className="bg-white/50 dark:bg-white/5">
-                  <CardContent className="p-4 space-y-3">
-                    <div className="flex items-center gap-2">
-                      <SlidersHorizontal className="h-5 w-5 text-primary" />
-                      <h4 className="font-semibold">Playground</h4>
-                    </div>
-                    <p className="text-sm text-muted-foreground">
-                      Explore players interactively with filters and search
-                    </p>
-                    <Button variant="outline" size="sm" asChild className="w-full">
-                      <Link href="/playground">
-                        Open Playground
-                        <ExternalLink className="ml-2 h-3 w-3" />
-                      </Link>
-                    </Button>
-                  </CardContent>
-                </Card>
-
-                {/* Run Now Option */}
-                <Card className="bg-white/50 dark:bg-white/5">
-                  <CardContent className="p-4 space-y-3">
-                    <div className="flex items-center gap-2">
-                      <Play className="h-5 w-5 text-primary" />
-                      <h4 className="font-semibold">Run Now</h4>
-                    </div>
-                    <p className="text-sm text-muted-foreground">
-                      Make a test API call right here to see it work
-                    </p>
-                    <Button
-                      size="sm"
-                      onClick={runOnboardingDemo}
-                      disabled={onboardingDemoLoading}
-                      className="w-full"
+                      <Eye className="h-3.5 w-3.5" strokeWidth={2} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={copyKey}
+                      title="Copy the key"
+                      className="cursor-pointer text-white/70 transition-colors duration-150 hover:text-white"
                     >
-                      {onboardingDemoLoading ? (
-                        <Loader2 className="h-3 w-3 mr-1 animate-spin" />
-                      ) : (
-                        <Play className="h-3 w-3 mr-1" />
-                      )}
-                      Try It
-                    </Button>
-                  </CardContent>
-                </Card>
+                      <Copy className="h-3.5 w-3.5" strokeWidth={2} />
+                    </button>
+                  </div>
+                </div>
+                <div className="mt-3 overflow-hidden font-plex text-[14px] text-ellipsis whitespace-nowrap text-[#faf9f5]">
+                  {copied ? "COPIED TO CLIPBOARD ✓" : reveal ? apiKey : `2k_${"•".repeat(25)}${apiKey.slice(-4)}`}
+                </div>
+                <div className="mt-2 font-plex text-[8px] text-white/45">
+                  {reveal ? "CLICK THE EYE TO MASK AGAIN" : "SEND IT IN THE X-API-KEY HEADER"}
+                </div>
               </div>
 
-              {/* Demo Result */}
-              {onboardingDemoResult && (
-                <div className="mt-4 rounded-lg bg-slate-100 dark:bg-slate-900 p-4">
-                  {onboardingDemoResult.success ? (
-                    <>
-                      <Badge variant="default" className="mb-2">
-                        Success! Found {onboardingDemoResult.data?.length || 0} elite players (95+ rating)
-                      </Badge>
-                      <pre className="text-xs overflow-auto max-h-40 mt-2">
-                        {JSON.stringify(onboardingDemoResult.data?.slice(0, 3).map((p: any) => ({
-                          name: p.name,
-                          team: p.team,
-                          overall: p.overall,
-                          position: p.position
-                        })), null, 2)}
-                      </pre>
-                    </>
+              <div className="rounded-[14px] border border-[#e5e2da] bg-white px-[18px] py-4">
+                <div className={CARD_LABEL}>THIS HOUR</div>
+                <div className="mt-2 flex items-baseline gap-1.5">
+                  <span className="font-display text-[32px] leading-none font-extrabold">
+                    {stats?.requestCount ?? "—"}
+                  </span>
+                  <span className="font-plex text-[11px] text-[#8a8577]">
+                    / {stats?.rateLimit ?? "—"}
+                  </span>
+                </div>
+                <div className="mt-2.5 h-1.5 rounded-full bg-[#f1efe8]">
+                  <div
+                    className="h-full rounded-full bg-[#1a1918] transition-[width] duration-400"
+                    style={{ width: `${usagePct}%` }}
+                  />
+                </div>
+                <div className="mt-2 font-plex text-[8px] text-[#b5b0a1]">
+                  {resetsInMin !== null ? `RESETS IN ${resetsInMin} MIN` : "…"}
+                </div>
+              </div>
+
+              <div className="rounded-[14px] border border-[#e5e2da] bg-white px-[18px] py-4">
+                <div className={CARD_LABEL}>ALL TIME</div>
+                <div className="mt-2 font-display text-[32px] leading-none font-extrabold">
+                  {stats ? stats.totalRequests.toLocaleString() : "—"}
+                </div>
+                <div className="mt-2.5 font-plex text-[8px] text-[#b5b0a1]">
+                  {stats ? `REQUESTS SINCE ${formatDate(stats.apiKey.createdAt)}` : "…"}
+                </div>
+              </div>
+            </div>
+
+            {/* Recent requests */}
+            <div
+              className="mt-3.5 overflow-hidden rounded-[14px] border border-[#e5e2da] bg-white animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
+              style={{ animationDelay: "120ms" }}
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2 border-b border-[#f1efe8] px-[18px] py-3">
+                <span className="font-plex text-[9.5px] tracking-[0.12em] text-[#8a8577]">
+                  RECENT REQUESTS — LAST 10
+                </span>
+                <span className="font-plex text-[8.5px] text-[#b5b0a1]">
+                  ROWS LINK BACK INTO THE PRODUCT
+                </span>
+              </div>
+              <div className="overflow-x-auto">
+                <div className="min-w-[640px]">
+                  {stats?.recentRequests.length ? (
+                    stats.recentRequests.map((r, i) => {
+                      const link = deepLink(r.endpoint);
+                      const row = (
+                        <>
+                          <span className="font-plex text-[8.5px] text-[#b5b0a1]">
+                            {timeAgo(r.timestamp)}
+                          </span>
+                          <span className="font-plex text-[9px] font-bold text-[#57534a]">
+                            {r.method}
+                          </span>
+                          <span className="overflow-hidden font-plex text-[10.5px] text-ellipsis whitespace-nowrap">
+                            {r.endpoint}
+                          </span>
+                          <span
+                            className="font-plex text-[10px] font-bold"
+                            style={{ color: statusColor(r.statusCode) }}
+                          >
+                            {r.statusCode}
+                          </span>
+                          <span className="text-right font-plex text-[9.5px] text-[#8a8577]">
+                            {r.responseTime}MS
+                          </span>
+                          <span className="text-right font-plex text-[8.5px] font-bold text-[#57534a]">
+                            {link?.label ?? ""}
+                          </span>
+                        </>
+                      );
+                      const rowClass =
+                        "grid grid-cols-[70px_44px_minmax(220px,1fr)_46px_60px_140px] items-center gap-3 border-b border-[#faf8f2] px-[18px] py-2 text-[#1a1918] no-underline";
+                      return link ? (
+                        <Link
+                          key={i}
+                          href={link.href}
+                          className={cn(rowClass, "transition-colors duration-100 hover:bg-[#faf8f2]")}
+                        >
+                          {row}
+                        </Link>
+                      ) : (
+                        <div key={i} className={rowClass}>
+                          {row}
+                        </div>
+                      );
+                    })
                   ) : (
-                    <Badge variant="destructive">
-                      Error: {onboardingDemoResult.error?.message || "Request failed"}
-                    </Badge>
+                    <div className="px-[18px] py-8 text-center font-plex text-[9px] tracking-[0.08em] text-[#b5b0a1]">
+                      {stats ? "NO REQUESTS YET — MAKE YOUR FIRST CALL BELOW" : "LOADING…"}
+                    </div>
                   )}
                 </div>
-              )}
-            </CardContent>
-          </Card>
-        )}
-
-        <div className="space-y-6">
-          {/* API Key Section */}
-          <GameCard showCorners={false} hoverEffect={false}>
-            <CardHeader>
-              <CardTitle className="font-rajdhani text-2xl">API Key</CardTitle>
-              <CardDescription>
-                Use this key to authenticate your API requests
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <ApiKeyDisplay
-                apiKey={apiKey}
-                createdAt={stats.apiKey.createdAt}
-                onRegenerate={handleRegenerate}
-              />
-            </CardContent>
-          </GameCard>
-
-          {/* Usage Stats */}
-          <div className="grid gap-6 md:grid-cols-3">
-            <GameCard showCorners={false} hoverEffect={false}>
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center gap-2 text-sm font-medium font-rajdhani text-lg">
-                  <Activity className="h-4 w-4 text-primary" />
-                  Requests This Hour
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="mb-2 flex items-baseline gap-2">
-                  <span className="text-3xl font-bold font-rajdhani">
-                    {stats.requestCount}
-                  </span>
-                  <span className="text-sm text-slate-600 dark:text-slate-400">
-                    / {stats.rateLimit}
-                  </span>
-                </div>
-                <Progress value={progressPercentage} className="mb-2" />
-                <p className="text-xs text-slate-600 dark:text-slate-400">
-                  {stats.requestsRemaining} requests remaining
-                </p>
-              </CardContent>
-            </GameCard>
-
-            <GameCard showCorners={false} hoverEffect={false}>
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center gap-2 text-sm font-medium font-rajdhani text-lg">
-                  <TrendingUp className="h-4 w-4 text-green-500" />
-                  Total Requests
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="mb-2 text-3xl font-bold font-rajdhani">
-                  {stats.totalRequests.toLocaleString()}
-                </div>
-                <p className="text-xs text-slate-600 dark:text-slate-400">
-                  All-time API requests
-                </p>
-              </CardContent>
-            </GameCard>
-
-            <GameCard showCorners={false} hoverEffect={false}>
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center gap-2 text-sm font-medium font-rajdhani text-lg">
-                  <AlertCircle className="h-4 w-4 text-amber-500" />
-                  Rate Limit Reset
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="mb-2 text-3xl font-bold font-rajdhani">
-                  {calculateTimeUntilReset(stats.resetAt)}
-                </div>
-                <p className="text-xs text-slate-600 dark:text-slate-400">
-                  Until limit resets
-                </p>
-              </CardContent>
-            </GameCard>
-          </div>
-
-          {/* Recent Requests */}
-          <GameCard showCorners={false} hoverEffect={false}>
-            <CardHeader>
-              <CardTitle className="font-rajdhani text-2xl">Recent Requests</CardTitle>
-              <CardDescription>
-                Your last 10 API requests
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              {stats.recentRequests.length === 0 ? (
-                <Alert>
-                  <AlertCircle className="h-4 w-4" />
-                  <AlertDescription>
-                    No requests yet. Start using your API key to see request
-                    logs here.
-                  </AlertDescription>
-                </Alert>
-              ) : (
-                <div className="overflow-x-auto">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>Timestamp</TableHead>
-                        <TableHead>Endpoint</TableHead>
-                        <TableHead>Method</TableHead>
-                        <TableHead>Status</TableHead>
-                        <TableHead className="text-right">
-                          Response Time
-                        </TableHead>
-                        <TableHead className="text-right">View</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {stats.recentRequests.map((request, index) => {
-                        const deepLink = parseEndpointToDeepLink(request.endpoint);
-                        return (
-                          <TableRow key={index}>
-                            <TableCell className="text-sm">
-                              {formatTimestamp(request.timestamp)}
-                            </TableCell>
-                            <TableCell className="font-mono text-xs">
-                              {request.endpoint}
-                            </TableCell>
-                            <TableCell>
-                              <Badge variant={getMethodColor(request.method)}>
-                                {request.method}
-                              </Badge>
-                            </TableCell>
-                            <TableCell>
-                              <Badge variant={getStatusColor(request.statusCode)}>
-                                {request.statusCode}
-                              </Badge>
-                            </TableCell>
-                            <TableCell className="text-right text-sm">
-                              {request.responseTime}ms
-                            </TableCell>
-                            <TableCell className="text-right">
-                              {deepLink.available ? (
-                                <Link
-                                  href={deepLink.href}
-                                  className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
-                                >
-                                  {deepLink.label}
-                                  <ExternalLink className="h-3 w-3" />
-                                </Link>
-                              ) : (
-                                <span className="text-xs text-muted-foreground">-</span>
-                              )}
-                            </TableCell>
-                          </TableRow>
-                        );
-                      })}
-                    </TableBody>
-                  </Table>
-                </div>
-              )}
-            </CardContent>
-          </GameCard>
-
-          {/* Explore Your Data */}
-          <GameCard showCorners={false} hoverEffect={false}>
-            <CardHeader className="pb-4">
-              <CardTitle className="font-rajdhani text-2xl">Explore Your Data</CardTitle>
-              <CardDescription>
-                Preview what your API returns with our interactive tools
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="grid gap-6 sm:grid-cols-3">
-                {/* Player Playground Card */}
-                <GameCard 
-                  variant="hollow" 
-                  className="space-y-3 p-4 bg-white/50 dark:bg-white/5"
-                  hoverEffect={true}
-                  showCorners={false}
-                >
-                  <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10">
-                    <SlidersHorizontal className="h-6 w-6 text-primary" />
-                  </div>
-                  <h4 className="font-semibold font-rajdhani text-lg">Player Playground</h4>
-                  <p className="text-sm text-muted-foreground">
-                    Filter through all players interactively
-                  </p>
-                  <Button variant="outline" size="sm" asChild className="w-full">
-                    <Link href="/playground">
-                      Explore Players
-                      <ExternalLink className="ml-2 h-3 w-3" />
-                    </Link>
-                  </Button>
-                </GameCard>
-
-                {/* Team Browser Card */}
-                <GameCard 
-                  variant="hollow" 
-                  className="space-y-3 p-4 bg-white/50 dark:bg-white/5"
-                  hoverEffect={true}
-                  showCorners={false}
-                >
-                  <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10">
-                    <Users className="h-6 w-6 text-primary" />
-                  </div>
-                  <h4 className="font-semibold font-rajdhani text-lg">Team Browser</h4>
-                  <p className="text-sm text-muted-foreground">
-                    View rosters and team statistics
-                  </p>
-                  <Button variant="outline" size="sm" asChild className="w-full">
-                    <Link href="/teams">
-                      Browse Teams
-                      <ExternalLink className="ml-2 h-3 w-3" />
-                    </Link>
-                  </Button>
-                </GameCard>
-
-                {/* API Docs Card */}
-                <GameCard 
-                  variant="hollow" 
-                  className="space-y-3 p-4 bg-white/50 dark:bg-white/5"
-                  hoverEffect={true}
-                  showCorners={false}
-                >
-                  <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10">
-                    <Code2 className="h-6 w-6 text-primary" />
-                  </div>
-                  <h4 className="font-semibold font-rajdhani text-lg">API Docs</h4>
-                  <p className="text-sm text-muted-foreground">
-                    Reference and code examples
-                  </p>
-                  <Button variant="outline" size="sm" asChild className="w-full">
-                    <Link href="/docs">
-                      View Docs
-                      <ExternalLink className="ml-2 h-3 w-3" />
-                    </Link>
-                  </Button>
-                </GameCard>
               </div>
-            </CardContent>
-          </GameCard>
-        </div>
+            </div>
+
+            {/* First call strip */}
+            <div
+              className="my-3.5 mb-12 flex flex-wrap items-center gap-x-4 gap-y-3 rounded-[14px] border border-[#e5e2da] bg-white px-[18px] py-3.5 animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
+              style={{ animationDelay: "180ms" }}
+            >
+              <span className="shrink-0 font-plex text-[9.5px] tracking-[0.1em] text-[#8a8577]">
+                FIRST CALL?
+              </span>
+              <span className="min-w-[200px] flex-1 overflow-hidden font-plex text-[10.5px] text-ellipsis whitespace-nowrap text-[#57534a]">
+                curl -H &quot;X-API-Key: {maskKey(apiKey)}&quot;
+                api.nba2kapi.com/api/players?minRating=95
+              </span>
+              <button
+                type="button"
+                onClick={copyCurl}
+                className="shrink-0 cursor-pointer rounded-full border border-[#e5e2da] bg-white px-[13px] py-1.5 text-[11.5px] font-semibold text-[#1a1918] transition-[border-color,transform] duration-150 hover:border-[#1a1918] active:scale-[0.97] motion-reduce:transition-none"
+              >
+                Copy
+              </button>
+              <Link
+                href="/playground"
+                className="shrink-0 rounded-full bg-[#1a1918] px-[13px] py-1.5 text-[11.5px] font-semibold text-[#faf9f5] no-underline transition-[background,transform] duration-150 hover:bg-[#333] active:scale-[0.97] motion-reduce:transition-none"
+              >
+                Run it in the playground →
+              </Link>
+            </div>
+          </>
+        )}
       </div>
 
-      <RegistrationDialog
-        open={showRegistration}
-        onOpenChange={setShowRegistration}
-        onSuccess={handleRegistrationSuccess}
+      <FooterStrip width="narrow" />
+
+      <KeyDialog
+        open={showDialog}
+        onOpenChange={setShowDialog}
+        onSuccess={(key) => setApiKey(key)}
       />
-    </>
+    </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -151,10 +151,10 @@ export default function Home() {
     }
   };
 
+  // Don't close the dialog or navigate here: the key is shown in full exactly
+  // once on the dialog's second step, and its own buttons navigate onward.
   const handleRegistrationSuccess = () => {
     setHasApiKey(true);
-    setShowRegistration(false);
-    router.push("/dashboard");
   };
 
   const copyTeaserUrl = () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import { toast } from "sonner";
 import { api } from "../convex/_generated/api";
 import { TopNav } from "@/components/chrome/top-nav";
 import { SiteFooter } from "@/components/chrome/site-footer";
-import { RegistrationDialog } from "@/components/registration-dialog";
+import { KeyDialog } from "@/components/chrome/key-dialog";
 import { getRatingClasses, getRatingTier, getAttributeColor } from "@/lib/rating-colors";
 import { getTeamAbbreviation } from "@/lib/team-abbr";
 import { API_KEY_STORAGE_KEY } from "@/lib/constants";
@@ -633,7 +633,7 @@ export default function Home() {
         <SiteFooter />
       </div>
 
-      <RegistrationDialog
+      <KeyDialog
         open={showRegistration}
         onOpenChange={setShowRegistration}
         onSuccess={handleRegistrationSuccess}

--- a/components/chrome/key-dialog.tsx
+++ b/components/chrome/key-dialog.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Check } from "lucide-react";
+import { useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { API_KEY_STORAGE_KEY } from "@/lib/constants";
+import { cn } from "@/lib/utils";
+
+type KeyDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess?: (apiKey: string) => void;
+};
+
+const FIELD_LABEL = "mb-[5px] font-plex text-[8.5px] tracking-[0.1em] text-[#8a8577]";
+const FIELD_INPUT =
+  "w-full rounded-[10px] border border-[#e5e2da] bg-[#faf9f5] px-3.5 py-2.5 font-body text-[13.5px] text-[#1a1918] outline-none transition-[border-color,box-shadow] duration-150 placeholder:text-[#b5b0a1] focus:border-[#1a1918] focus:bg-white focus:shadow-[0_0_0_3px_rgba(26,25,24,0.07)]";
+
+/**
+ * Two-step key creation modal (paper/editorial design): form, then the key
+ * shown in full exactly once. The key is the login — it lands in
+ * localStorage and the dashboard remembers the browser.
+ */
+export function KeyDialog({ open, onOpenChange, onSuccess }: KeyDialogProps) {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [purpose, setPurpose] = useState("");
+  const [newKey, setNewKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const createApiKey = useMutation(api.apiKeys.createApiKey);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const result = await createApiKey({ email, name, purpose: purpose || undefined });
+      setNewKey(result.apiKey);
+      localStorage.setItem(API_KEY_STORAGE_KEY, result.apiKey);
+      onSuccess?.(result.apiKey);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create the key — try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const copyKey = () => {
+    if (!newKey) return;
+    navigator.clipboard.writeText(newKey).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    });
+  };
+
+  const handleClose = (next: boolean) => {
+    if (!next && newKey) {
+      setName("");
+      setEmail("");
+      setPurpose("");
+      setNewKey(null);
+      setError(null);
+      setCopied(false);
+    }
+    onOpenChange(next);
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleClose}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-[rgba(26,25,24,0.35)] backdrop-blur-[2px]" />
+        <Dialog.Content className="fixed top-1/2 left-1/2 z-50 w-[min(420px,calc(100vw-40px))] -translate-x-1/2 -translate-y-1/2 rounded-[18px] border border-[#e5e2da] bg-white px-7 py-[26px] font-body text-[#1a1918] shadow-[0_40px_80px_-24px_rgba(26,25,24,0.5)] animate-[pop-in_220ms_cubic-bezier(0.23,1,0.32,1)_both] focus:outline-none motion-reduce:animate-none">
+          {!newKey ? (
+            <>
+              <Dialog.Title className="m-0 font-display text-[26px] font-extrabold tracking-[-0.03em]">
+                Get your key
+              </Dialog.Title>
+              <Dialog.Description className="mt-1.5 mb-0 text-[13px] leading-[1.5] text-[#57534a]">
+                Free. 100 requests an hour. No credit card, no password — the key is your login.
+              </Dialog.Description>
+              <form onSubmit={handleSubmit} className="mt-[18px] flex flex-col gap-3">
+                <div>
+                  <div className={FIELD_LABEL}>NAME</div>
+                  <input
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    required
+                    disabled={loading}
+                    placeholder="Will K"
+                    className={FIELD_INPUT}
+                  />
+                </div>
+                <div>
+                  <div className={FIELD_LABEL}>EMAIL</div>
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    disabled={loading}
+                    placeholder="will@example.com"
+                    className={FIELD_INPUT}
+                  />
+                </div>
+                <div>
+                  <div className={FIELD_LABEL}>
+                    WHAT ARE YOU BUILDING? <span className="text-[#b5b0a1]">— OPTIONAL</span>
+                  </div>
+                  <input
+                    value={purpose}
+                    onChange={(e) => setPurpose(e.target.value)}
+                    disabled={loading}
+                    placeholder="A fantasy draft tool…"
+                    className={FIELD_INPUT}
+                  />
+                </div>
+                {error && (
+                  <div className="rounded-[10px] border border-[#c03a2b]/30 bg-[#c03a2b]/5 px-3.5 py-2.5 text-[12.5px] text-[#c03a2b]">
+                    {error}
+                  </div>
+                )}
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="mt-1 cursor-pointer rounded-full bg-[#1a1918] py-3 text-center text-[14px] font-semibold text-[#faf9f5] transition-[background,transform] duration-150 select-none hover:bg-[#333] active:scale-[0.98] disabled:cursor-default disabled:opacity-60 motion-reduce:transition-none"
+                >
+                  {loading ? "Creating…" : "Create my key"}
+                </button>
+                <p className="m-0 text-center font-plex text-[8px] text-[#b5b0a1]">
+                  3 KEYS MAX PER EMAIL · RATE LIMITED BY IP
+                </p>
+              </form>
+            </>
+          ) : (
+            <>
+              <div className="flex items-center gap-2.5">
+                <span className="flex h-[34px] w-[34px] items-center justify-center rounded-full bg-[#eaf5ee] text-[#0a7f3f]">
+                  <Check className="h-4 w-4" strokeWidth={2.5} />
+                </span>
+                <Dialog.Title className="m-0 font-display text-[24px] font-extrabold tracking-[-0.03em]">
+                  You&apos;re in
+                </Dialog.Title>
+              </div>
+              <div className="mt-4 flex items-center overflow-hidden rounded-[10px] bg-[#1a1918]">
+                <span className="flex-1 overflow-hidden px-3.5 py-3 font-plex text-[12px] text-ellipsis whitespace-nowrap text-[#6ee7a0]">
+                  {newKey}
+                </span>
+                <button
+                  type="button"
+                  onClick={copyKey}
+                  className="cursor-pointer border-l border-white/12 px-3.5 py-3 font-plex text-[9.5px] text-white/70 transition-colors duration-150 hover:text-white"
+                >
+                  {copied ? "COPIED ✓" : "COPY"}
+                </button>
+              </div>
+              <Dialog.Description className="mt-2.5 mb-0 text-[12px] leading-[1.5] text-[#57534a]">
+                Saved to this browser — the dashboard will remember you. Copy it somewhere safe
+                too; it&apos;s shown in full only this once.
+              </Dialog.Description>
+              <div className="mt-[18px] mb-1.5 font-plex text-[8.5px] tracking-[0.1em] text-[#8a8577]">
+                YOUR FIRST CALL
+              </div>
+              <div className="overflow-x-auto rounded-[10px] border border-[#e5e2da] bg-[#faf9f5] px-3.5 py-[11px] font-plex text-[10.5px] leading-[1.6] text-[#57534a]">
+                curl -H &quot;X-API-Key:{" "}
+                <span className="font-bold text-[#1a1918]">{newKey.slice(0, 12)}…</span>&quot; \
+                <br />
+                &nbsp;&nbsp;api.nba2kapi.com/api/players?minRating=95
+              </div>
+              <div className="mt-3.5 flex gap-2">
+                <Link
+                  href="/dashboard"
+                  onClick={() => handleClose(false)}
+                  className="flex-1 cursor-pointer rounded-full bg-[#1a1918] py-2.5 text-center text-[12.5px] font-semibold text-[#faf9f5] no-underline transition-[background,transform] duration-150 select-none hover:bg-[#333] active:scale-[0.98] motion-reduce:transition-none"
+                >
+                  Go to the dashboard →
+                </Link>
+                <Link
+                  href="/playground"
+                  onClick={() => handleClose(false)}
+                  className={cn(
+                    "flex-1 rounded-full border border-[#e5e2da] bg-white py-2.5 text-center text-[12.5px] font-semibold text-[#1a1918] no-underline transition-[border-color,transform] duration-150 hover:border-[#1a1918] active:scale-[0.98] motion-reduce:transition-none"
+                  )}
+                >
+                  Open playground
+                </Link>
+              </div>
+            </>
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/components/chrome/top-nav.tsx
+++ b/components/chrome/top-nav.tsx
@@ -60,6 +60,8 @@ type TopNavProps = {
   hasApiKey?: boolean;
   /** Page shell width: narrow 1280 (Board), default 1360, wide 1440 (Playground). */
   width?: "narrow" | "default" | "wide";
+  /** Signed-in chip: masked key ("2k_••••xB7q") shown next to the CTA. */
+  maskedKey?: string | null;
 };
 
 export const SHELL_WIDTHS = {
@@ -72,7 +74,12 @@ export const SHELL_WIDTHS = {
  * Shared chrome for reskinned (paper/editorial) pages: wordmark, pill nav,
  * search pill, GitHub star chip, and the primary API-key CTA.
  */
-export function TopNav({ onCtaClick, hasApiKey = false, width = "default" }: TopNavProps) {
+export function TopNav({
+  onCtaClick,
+  hasApiKey = false,
+  width = "default",
+  maskedKey = null,
+}: TopNavProps) {
   const ctaLabel = hasApiKey ? "View dashboard" : "Get an API key";
   const pathname = usePathname();
   const router = useRouter();
@@ -156,6 +163,12 @@ export function TopNav({ onCtaClick, hasApiKey = false, width = "default" }: Top
           {stars ?? "★"}
         </a>
 
+        {maskedKey && (
+          <span className="inline-flex items-center gap-[7px] rounded-full border border-[#e5e2da] bg-white px-3.5 py-2 font-plex text-[10px] text-[#57534a]">
+            <span className="h-[7px] w-[7px] rounded-full bg-[#0a7f3f]" />
+            {maskedKey}
+          </span>
+        )}
         {onCtaClick ? (
           <button type="button" onClick={onCtaClick} className={cn(ctaClasses, "cursor-pointer")}>
             {ctaLabel}

--- a/components/legacy-chrome.tsx
+++ b/components/legacy-chrome.tsx
@@ -7,7 +7,7 @@ import { Footer } from "@/components/footer";
 // Routes that have been migrated to the new (paper/editorial) design render
 // their own chrome (TopNav / SiteFooter) inside the page, so the legacy
 // header/footer must not double up on them.
-const RESKINNED_ROUTES = new Set(["/", "/playground", "/teams", "/lineups"]);
+const RESKINNED_ROUTES = new Set(["/", "/playground", "/teams", "/lineups", "/dashboard"]);
 const RESKINNED_PREFIXES = ["/teams/", "/players/"];
 
 function isReskinned(pathname: string) {

--- a/convex/apiKeys.ts
+++ b/convex/apiKeys.ts
@@ -323,8 +323,10 @@ export const getApiKeyStats = query({
       .withIndex("by_key", (q) => q.eq("key", args.key))
       .first();
 
-    if (!apiKey) {
-      throw new Error("API key not found");
+    // Stale or regenerated-away keys return null (never throw): the dashboard
+    // clears the browser copy and shows the signup state instead of crashing.
+    if (!apiKey || !apiKey.isActive) {
+      return null;
     }
 
     // Use atomic counter for current hour requests


### PR DESCRIPTION
## What

Screen 7: **Final Dashboard.dc.html** as the real `/dashboard`, plus the design's two-step key-creation modal as a shared component now used by both the dashboard and the landing page.

## How

- All numbers are live from `getApiKeyStats`: hourly usage vs rate limit with a reset countdown (30s tick), all-time request count, and the last-10 request log.
- Each log row deep-links back into the product per the mock: `/api/players/slug/x` opens the dossier, roster calls open the team page, `/api/players?...` reopens the playground with the query params carried over.
- Key card masks by default (`2k_...n1qh`), eye toggles reveal, copy works; regenerate asks for confirmation, then reveals the new key with a copy-it-now toast (old key dies immediately, matching the existing mutation).
- `KeyDialog` reimplements RegistrationDialog's logic (same `createApiKey` mutation, localStorage persistence) in the design's two-step layout: form with the "3 keys max / IP limited" fine print, then the key shown in full exactly once with the first-call curl. Landing now uses it, so the whole signup path is on the new design.
- TopNav shows the green-dot masked-key chip when signed in, per the handoff's chrome spec.
- The mock's "VIEW SIGN-UP FLOW" link was a prototype affordance and is intentionally dropped; real users hit the flow via the CTA when they have no key.

## Verified

Build + tsc clean. Browser QA of the full journey: no-key state opens the dialog, form submits against the dev deployment, step 2 shows the key once, dashboard renders live stats (created date, 500 req/hr tier, masked chip in nav, localStorage set). Throwaway QA key deactivated and browser storage cleared afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)