### PR TITLE
feat: docs reskin — 3-column reference layout, docs kit, all 8 pages converted

### DIFF
--- a/app/docs/authentication/page.tsx
+++ b/app/docs/authentication/page.tsx
@@ -1,146 +1,41 @@
+"use client";
+
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { CodeBlock } from "@/components/code-block";
-import { LanguageTabs } from "@/components/language-tabs";
-import { AlertCircle, CheckCircle2, XCircle } from "lucide-react";
+import {
+  CodeRail,
+  DarkCode,
+  DocColumns,
+  DocH1,
+  DocLabel,
+  DocP,
+  FinePrint,
+  ParamsTable,
+} from "@/components/docs/kit";
 
-export default function AuthenticationPage() {
-  return (
-    <div className="space-y-8">
-      <div>
-        <h1 className="mb-4 text-4xl font-bold">Authentication</h1>
-        <p className="text-lg text-slate-600 dark:text-slate-400">
-          Learn how to authenticate your API requests using API keys.
-        </p>
-      </div>
-
-      <div className="space-y-6">
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">API Keys</h2>
-          <p className="mb-4 text-slate-600 dark:text-slate-400">
-            The NBA 2K Ratings API uses API keys to authenticate requests. All requests must include
-            a valid API key in the <code className="rounded bg-slate-100 px-1.5 py-0.5 text-sm dark:bg-slate-800">X-API-Key</code> header.
-          </p>
-          <Button asChild>
-            <Link href="/dashboard">Get Your API Key</Link>
-          </Button>
-        </div>
-
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Including your API key</h2>
-          <p className="mb-4 text-slate-600 dark:text-slate-400">
-            Add your API key to the <code className="rounded bg-slate-100 px-1.5 py-0.5 text-sm dark:bg-slate-800">X-API-Key</code> header in every request:
-          </p>
-          <LanguageTabs
-            examples={{
-              javascript: `const response = await fetch(
-  'https://api.nba2kapi.com/api/players',
+const SAMPLES = [
   {
-    headers: {
-      'X-API-Key': 'your_api_key_here'
-    }
-  }
-);`,
-              python: `import requests
-
-response = requests.get(
-    'https://api.nba2kapi.com/api/players',
-    headers={'X-API-Key': 'your_api_key_here'}
-)`,
-              curl: `curl -X GET \\
-  'https://api.nba2kapi.com/api/players' \\
+    label: "cURL",
+    code: `curl 'https://api.nba2kapi.com/api/players' \\
   -H 'X-API-Key: your_api_key_here'`,
-            }}
-          />
-        </div>
+  },
+  {
+    label: "JS",
+    code: `const res = await fetch(
+  'https://api.nba2kapi.com/api/players',
+  { headers: { 'X-API-Key': process.env.NBA2K_API_KEY } }
+);`,
+  },
+  {
+    label: "Python",
+    code: `import os, requests
 
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Best Practices</h2>
+res = requests.get(
+  'https://api.nba2kapi.com/api/players',
+  headers={'X-API-Key': os.getenv('NBA2K_API_KEY')})`,
+  },
+];
 
-          <div className="space-y-4">
-            <div className="flex gap-3 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-900 dark:bg-green-950">
-              <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-              <div>
-                <h4 className="mb-1 font-semibold text-green-900 dark:text-green-100">
-                  Store API keys in environment variables
-                </h4>
-                <p className="text-sm text-green-700 dark:text-green-300">
-                  Never hardcode API keys in your source code. Use environment variables instead.
-                </p>
-                <CodeBlock
-                  code={`# .env
-NBA2K_API_KEY=your_api_key_here
-
-# JavaScript
-const apiKey = process.env.NBA2K_API_KEY;
-
-# Python
-import os
-api_key = os.getenv('NBA2K_API_KEY')`}
-                  filename=".env"
-                  className="mt-3"
-                />
-              </div>
-            </div>
-
-            <div className="flex gap-3 rounded-lg border border-yellow-200 bg-yellow-50 p-4 dark:border-yellow-900 dark:bg-yellow-950">
-              <AlertCircle className="h-5 w-5 shrink-0 text-yellow-600 dark:text-yellow-400" />
-              <div>
-                <h4 className="mb-1 font-semibold text-yellow-900 dark:text-yellow-100">
-                  Add .env to .gitignore
-                </h4>
-                <p className="text-sm text-yellow-700 dark:text-yellow-300">
-                  Prevent committing your API keys to version control.
-                </p>
-                <CodeBlock
-                  code={`# .gitignore
-.env
-.env.local
-.env.*.local`}
-                  filename=".gitignore"
-                  className="mt-3"
-                />
-              </div>
-            </div>
-
-            <div className="flex gap-3 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900 dark:bg-red-950">
-              <XCircle className="h-5 w-5 shrink-0 text-red-600 dark:text-red-400" />
-              <div>
-                <h4 className="mb-1 font-semibold text-red-900 dark:text-red-100">
-                  Never expose API keys in client-side code
-                </h4>
-                <p className="text-sm text-red-700 dark:text-red-300">
-                  API calls should be made from your backend/server, not directly from the browser.
-                  Exposing keys in client-side JavaScript makes them publicly accessible.
-                </p>
-              </div>
-            </div>
-
-            <div className="flex gap-3 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-900 dark:bg-green-950">
-              <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-              <div>
-                <h4 className="mb-1 font-semibold text-green-900 dark:text-green-100">
-                  Regenerate compromised keys immediately
-                </h4>
-                <p className="text-sm text-green-700 dark:text-green-300">
-                  If you accidentally expose your API key, regenerate it immediately in your{" "}
-                  <Link href="/dashboard" className="underline">
-                    dashboard
-                  </Link>
-                  .
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Error Responses</h2>
-          <p className="mb-4 text-slate-600 dark:text-slate-400">
-            If authentication fails, you'll receive a 401 Unauthorized response:
-          </p>
-          <CodeBlock
-            code={`// Missing API key
+const ERRORS_401 = `// Missing key → 401
 {
   "success": false,
   "error": {
@@ -149,33 +44,95 @@ api_key = os.getenv('NBA2K_API_KEY')`}
   }
 }
 
-// Invalid API key
+// Invalid key → 401
 {
   "success": false,
   "error": {
     "message": "Invalid API key",
     "code": "INVALID_API_KEY"
   }
-}`}
-            language="json"
-          />
-        </div>
+}`;
 
-        <div className="space-y-4 rounded-lg border border-slate-200 bg-slate-50 p-6 dark:border-slate-800 dark:bg-slate-900">
-          <h3 className="text-lg font-semibold">Need help?</h3>
-          <p className="text-slate-600 dark:text-slate-400">
-            If you're having trouble with authentication, check out the{" "}
-            <Link href="/docs/errors" className="font-medium text-primary hover:underline">
-              error handling guide
-            </Link>{" "}
-            or view your{" "}
-            <Link href="/dashboard" className="font-medium text-primary hover:underline">
-              dashboard
-            </Link>{" "}
-            to verify your API key is active.
-          </p>
+export default function AuthenticationPage() {
+  return (
+    <DocColumns
+      rail={
+        <div className="flex flex-col gap-2.5">
+          <CodeRail samples={SAMPLES} />
+          <DarkCode title="401 UNAUTHORIZED">{ERRORS_401}</DarkCode>
         </div>
-      </div>
-    </div>
+      }
+    >
+      <DocH1>Authentication</DocH1>
+      <DocP>
+        Every request must carry a valid API key in the <code>X-API-Key</code> header. That&apos;s
+        the whole protocol — no OAuth, no tokens to refresh.
+      </DocP>
+
+      <DocLabel>THE KEY MODEL</DocLabel>
+      <ParamsTable
+        rows={[
+          {
+            name: "No password",
+            type: "design",
+            desc: (
+              <>
+                The key is the login. Get yours from the <Link href="/dashboard">dashboard</Link>{" "}
+                and you&apos;re done.
+              </>
+            ),
+          },
+          {
+            name: "3 keys per email",
+            type: "limit",
+            desc: <>Each email address can hold up to 3 active keys — one per project, say.</>,
+          },
+          {
+            name: "Regenerate anytime",
+            type: "recovery",
+            desc: (
+              <>
+                Exposed a key? Regenerate it immediately in the{" "}
+                <Link href="/dashboard">dashboard</Link>. The old key stops working at once.
+              </>
+            ),
+          },
+        ]}
+      />
+
+      <DocLabel>KEY HYGIENE</DocLabel>
+      <ParamsTable
+        rows={[
+          {
+            name: "Env vars, not source",
+            type: "do",
+            desc: (
+              <>
+                Never hardcode keys. Put <code>NBA2K_API_KEY=…</code> in <code>.env</code> and add{" "}
+                <code>.env</code> to <code>.gitignore</code>.
+              </>
+            ),
+          },
+          {
+            name: "Server-side only",
+            type: "don't",
+            desc: (
+              <>
+                Call the API from your backend, not the browser. A key in client-side JavaScript is
+                publicly readable.
+              </>
+            ),
+          },
+        ]}
+      />
+
+      <DocLabel>WHEN IT FAILS</DocLabel>
+      <DocP>
+        A missing or invalid key returns <code>401 Unauthorized</code> with the envelope shown on
+        the right. See the <Link href="/docs/errors">error handling guide</Link> for the full code
+        list, or check the <Link href="/dashboard">dashboard</Link> to verify your key is active.
+      </DocP>
+      <FinePrint>KEYS ARE CHECKED ON EVERY REQUEST · NO SESSION STATE.</FinePrint>
+    </DocColumns>
   );
 }

--- a/app/docs/endpoints/players/page.tsx
+++ b/app/docs/endpoints/players/page.tsx
@@ -1,256 +1,197 @@
-import { Badge } from "@/components/ui/badge";
-import { CodeBlock } from "@/components/code-block";
-import { LanguageTabs } from "@/components/language-tabs";
-import { TryItLiveButton } from "@/components/try-it-live-button";
+"use client";
+
+import Link from "next/link";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+  AuthPill,
+  CodeRail,
+  DocColumns,
+  DocLabel,
+  EndpointHeader,
+  FinePrint,
+  ParamsTable,
+} from "@/components/docs/kit";
 
-export default function PlayersEndpointPage() {
-  return (
-    <div className="space-y-8">
-      <div>
-        <div className="mb-4 flex items-center gap-3">
-          <Badge variant="outline" className="font-mono">
-            GET
-          </Badge>
-          <code className="text-2xl font-bold">/api/players</code>
-        </div>
-        <p className="text-lg text-slate-600 dark:text-slate-400">
-          Retrieve a list of NBA 2K players with optional filtering and pagination.
-        </p>
-        <div className="mt-4 flex gap-3">
-          <TryItLiveButton href="/playground" label="Explore All Players" />
-          <TryItLiveButton
-            href="/playground?minOverall=90"
-            label="Filter by Rating (90+)"
-            variant="secondary"
-          />
-        </div>
-      </div>
-
-      <div className="space-y-6">
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Query Parameters</h2>
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Parameter</TableHead>
-                  <TableHead>Type</TableHead>
-                  <TableHead>Description</TableHead>
-                  <TableHead>Default</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">teamType</TableCell>
-                  <TableCell>
-                    <code className="text-sm">curr | class | allt</code>
-                  </TableCell>
-                  <TableCell>Filter by team type (current, classic, all-time)</TableCell>
-                  <TableCell>
-                    <code className="text-sm">curr</code>
-                  </TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">team</TableCell>
-                  <TableCell>string</TableCell>
-                  <TableCell>Filter by team name</TableCell>
-                  <TableCell>-</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">position</TableCell>
-                  <TableCell>string</TableCell>
-                  <TableCell>Filter by position (PG, SG, SF, PF, C)</TableCell>
-                  <TableCell>-</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">minRating</TableCell>
-                  <TableCell>number</TableCell>
-                  <TableCell>Minimum overall rating (0-99)</TableCell>
-                  <TableCell>-</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">maxRating</TableCell>
-                  <TableCell>number</TableCell>
-                  <TableCell>Maximum overall rating (0-99)</TableCell>
-                  <TableCell>-</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">limit</TableCell>
-                  <TableCell>number</TableCell>
-                  <TableCell>Number of results to return (max 100)</TableCell>
-                  <TableCell>
-                    <code className="text-sm">50</code>
-                  </TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">cursor</TableCell>
-                  <TableCell>string</TableCell>
-                  <TableCell>Pagination cursor from previous response</TableCell>
-                  <TableCell>-</TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </div>
-        </div>
-
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Example Request</h2>
-          <LanguageTabs
-            examples={{
-              javascript: `const response = await fetch(
-  'https://api.nba2kapi.com/api/players?teamType=curr&minRating=90&limit=10',
+const SAMPLES = [
   {
-    headers: {
-      'X-API-Key': 'your_api_key_here'
-    }
-  }
+    label: "cURL",
+    code: `curl 'https://api.nba2kapi.com/api/players?\\
+  position=guard&era=all&\\
+  three_ball_gte=85&sort=overall:desc' \\
+  -H 'X-API-Key: YOUR_KEY'`,
+  },
+  {
+    label: "JS",
+    code: `const res = await fetch(
+  'https://api.nba2kapi.com/api/players?' +
+  'position=guard&era=all&three_ball_gte=85',
+  { headers: { 'X-API-Key': KEY } }
 );
+const { data } = await res.json();`,
+  },
+  {
+    label: "Python",
+    code: `import requests
 
-const data = await response.json();
-console.log(data.data); // Array of top 10 current players rated 90+`,
-              python: `import requests
+res = requests.get(
+  'https://api.nba2kapi.com/api/players',
+  params={'position': 'guard', 'era': 'all',
+          'three_ball_gte': 85},
+  headers={'X-API-Key': KEY})
+data = res.json()['data']`,
+  },
+];
 
-response = requests.get(
-    'https://api.nba2kapi.com/api/players',
-    params={
-        'teamType': 'curr',
-        'minRating': 90,
-        'limit': 10
-    },
-    headers={'X-API-Key': 'your_api_key_here'}
-)
-
-data = response.json()
-print(data['data'])  # Array of top 10 current players rated 90+`,
-              curl: `curl -X GET \\
-  'https://api.nba2kapi.com/api/players?teamType=curr&minRating=90&limit=10' \\
-  -H 'X-API-Key: your_api_key_here'`,
-            }}
-          />
-        </div>
-
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Example Response</h2>
-          <CodeBlock
-            code={`{
+const RESPONSE = `{
   "success": true,
   "data": [
     {
-      "_id": "abc123",
-      "name": "LeBron James",
-      "slug": "lebron-james",
-      "team": "Los Angeles Lakers",
+      "name": "Shai Gilgeous-Alexander",
+      "slug": "shai-gilgeous-alexander",
+      "team": "Oklahoma City Thunder",
       "teamType": "curr",
-      "overall": 97,
-      "positions": ["SF", "PF"],
-      "height": "6'9\\"",
-      "weight": "250 lbs",
-      "playerImage": "https://...",
-      "teamImg": "https://...",
-      "closeShot": 92,
-      "midRangeShot": 88,
-      "threePointShot": 44,
-      "freeThrow": 70,
-      "shotIQ": 95,
-      "offensiveConsistency": 95,
-      // ... 30+ more attributes
-      "lastUpdated": "2025-01-15T00:00:00.000Z"
+      "overall": 98,
+      "positions": ["PG", "SG"],
+      "attributes": { "threePointShot": 85, … },
+      "badges": { "total": 26, … }
     },
-    // ... more players
+    …
   ],
-  "pagination": {
-    "hasMore": true,
-    "nextCursor": "abc123",
-    "count": 10,
-    "limit": 10
-  },
-  "meta": {
-    "timestamp": "2025-01-15T00:00:00.000Z"
-  }
-}`}
-            language="json"
-          />
-        </div>
+  "meta": { "pagination": { "total": 231, "nextCursor": "50" } }
+}`;
 
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Response Fields</h2>
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Field</TableHead>
-                  <TableHead>Type</TableHead>
-                  <TableHead>Description</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">_id</TableCell>
-                  <TableCell>string</TableCell>
-                  <TableCell>Unique player identifier</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">name</TableCell>
-                  <TableCell>string</TableCell>
-                  <TableCell>Player's full name</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">slug</TableCell>
-                  <TableCell>string</TableCell>
-                  <TableCell>URL-friendly identifier (e.g., "lebron-james")</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">overall</TableCell>
-                  <TableCell>number</TableCell>
-                  <TableCell>Overall player rating (0-99)</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">positions</TableCell>
-                  <TableCell>string[]</TableCell>
-                  <TableCell>Player positions (PG, SG, SF, PF, C)</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">team</TableCell>
-                  <TableCell>string</TableCell>
-                  <TableCell>Team name</TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </div>
-        </div>
+export default function PlayersEndpointPage() {
+  return (
+    <DocColumns
+      rail={
+        <CodeRail
+          samples={SAMPLES}
+          response={RESPONSE}
+          playgroundHref="/playground?position=guard&era=all&three_ball_gte=85&sort=overall%3Adesc"
+        />
+      }
+    >
+      <EndpointHeader path="/api/players" title="List players">
+        <p className="m-0">
+          Every player in the database — 1,700+ across current, classic, and all-time rosters —
+          filterable on any attribute, sortable on any column. This is the endpoint the{" "}
+          <Link href="/playground">playground</Link> writes for you.
+        </p>
+      </EndpointHeader>
+      <AuthPill>REQUIRES X-API-KEY HEADER · 100 REQ/HR FREE</AuthPill>
 
-        <div className="space-y-4 rounded-lg border border-slate-200 bg-slate-50 p-6 dark:border-slate-800 dark:bg-slate-900">
-          <h3 className="text-lg font-semibold">Related Endpoints</h3>
-          <ul className="space-y-2 text-slate-600 dark:text-slate-400">
-            <li>
-              <code className="mr-2 rounded bg-white px-1.5 py-0.5 text-sm dark:bg-slate-950">
-                GET /api/players/slug/:slug
-              </code>
-              - Get a single player by slug (use <code className="text-xs">?teamType=class&team=Team Name</code> for players on multiple teams)
-            </li>
-            <li>
-              <code className="mr-2 rounded bg-white px-1.5 py-0.5 text-sm dark:bg-slate-950">
-                GET /api/players/search
-              </code>
-              - Search players by name
-            </li>
-            <li>
-              <code className="mr-2 rounded bg-white px-1.5 py-0.5 text-sm dark:bg-slate-950">
-                GET /api/teams
-              </code>
-              - Get all teams
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
+      <DocLabel>QUERY PARAMETERS</DocLabel>
+      <ParamsTable
+        rows={[
+          {
+            name: "era",
+            type: "string",
+            isNew: true,
+            desc: (
+              <>
+                <code>curr</code> (default), <code>class</code>, <code>allt</code> — or{" "}
+                <code>all</code> to search every era in one call. <code>teamType</code> remains a
+                supported alias.
+              </>
+            ),
+          },
+          {
+            name: "position",
+            type: "string",
+            desc: (
+              <>
+                Position or group: <code>PG</code>, <code>SG</code>, <code>SF</code>,{" "}
+                <code>PF</code>, <code>C</code> — or <code>guard</code>, <code>wing</code>,{" "}
+                <code>big</code>.
+              </>
+            ),
+          },
+          {
+            name: "team",
+            type: "string",
+            desc: (
+              <>
+                Filter to one team by full name, e.g. <code>Los Angeles Lakers</code> or{" "}
+                <code>1995-96 Chicago Bulls</code>.
+              </>
+            ),
+          },
+          {
+            name: "minRating / maxRating",
+            type: "number",
+            desc: <>Bound the overall rating, 0–99.</>,
+          },
+          {
+            name: "{attribute}_gte / _lte",
+            type: "number",
+            isNew: true,
+            desc: (
+              <>
+                Bound any of the 40+ attributes in snake_case: <code>three_ball_gte=85</code>,{" "}
+                <code>speed_lte=70</code>, <code>shot_iq_gte=90</code>, …
+              </>
+            ),
+          },
+          {
+            name: "sort",
+            type: "string",
+            isNew: true,
+            desc: (
+              <>
+                Any attribute plus direction: <code>sort=overall:desc</code> (default),{" "}
+                <code>sort=three_ball:asc</code>, <code>sort=name:asc</code>.
+              </>
+            ),
+          },
+          {
+            name: "fields",
+            type: "string",
+            isNew: true,
+            desc: (
+              <>
+                Trim the payload to just the fields you need:{" "}
+                <code>fields=name,overall,slug</code>.
+              </>
+            ),
+          },
+          {
+            name: "limit / cursor",
+            type: "number / string",
+            desc: (
+              <>
+                Page size (max 100, default 50) and the offset cursor from{" "}
+                <code>meta.pagination.nextCursor</code>.
+              </>
+            ),
+          },
+        ]}
+      />
+      <FinePrint>RESPONSES ARE CACHED 1H AND SUPPORT ETAG / 304 REVALIDATION.</FinePrint>
+
+      <DocLabel>RELATED ENDPOINTS</DocLabel>
+      <ParamsTable
+        rows={[
+          {
+            name: "/api/players/bulk",
+            type: "GET",
+            desc: <>The whole matching dataset in one call — one request against your rate limit.</>,
+          },
+          {
+            name: "/api/players/slug/:slug",
+            type: "GET",
+            desc: (
+              <>
+                One player, full detail: all attributes, badges, hot zones. Add{" "}
+                <code>?teamType=</code> for classic or all-time versions.
+              </>
+            ),
+          },
+          {
+            name: "/api/players/:id/history",
+            type: "GET",
+            desc: <>Weekly rating snapshots — the dossier&apos;s history chart uses this.</>,
+          },
+        ]}
+      />
+    </DocColumns>
   );
 }

--- a/app/docs/endpoints/players/page.tsx
+++ b/app/docs/endpoints/players/page.tsx
@@ -77,7 +77,7 @@ export default function PlayersEndpointPage() {
           <Link href="/playground">playground</Link> writes for you.
         </p>
       </EndpointHeader>
-      <AuthPill>REQUIRES X-API-KEY HEADER · 100 REQ/HR FREE</AuthPill>
+      <AuthPill>REQUIRES X-API-KEY HEADER · 500 REQ/HR FREE</AuthPill>
 
       <DocLabel>QUERY PARAMETERS</DocLabel>
       <ParamsTable

--- a/app/docs/endpoints/search/page.tsx
+++ b/app/docs/endpoints/search/page.tsx
@@ -1,114 +1,44 @@
-import { Badge } from "@/components/ui/badge";
-import { CodeBlock } from "@/components/code-block";
-import { LanguageTabs } from "@/components/language-tabs";
-import { TryItLiveButton } from "@/components/try-it-live-button";
+"use client";
+
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+  AuthPill,
+  CodeRail,
+  DocColumns,
+  DocLabel,
+  DocP,
+  EndpointHeader,
+  FinePrint,
+  ParamsTable,
+} from "@/components/docs/kit";
 
-export default function SearchEndpointPage() {
-  return (
-    <div className="space-y-8">
-      <div>
-        <div className="mb-4 flex items-center gap-3">
-          <Badge variant="outline" className="font-mono">
-            GET
-          </Badge>
-          <code className="text-2xl font-bold">/api/players/search</code>
-        </div>
-        <p className="text-lg text-slate-600 dark:text-slate-400">
-          Search for players by name with fuzzy matching support.
-        </p>
-        <div className="mt-4 flex gap-3">
-          <TryItLiveButton href="/playground?search=lebron" label="Try Search: LeBron" />
-          <TryItLiveButton
-            href="/playground?search=curry"
-            label="Try Search: Curry"
-            variant="secondary"
-          />
-        </div>
-      </div>
-
-      <div className="space-y-6">
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Query Parameters</h2>
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Parameter</TableHead>
-                  <TableHead>Type</TableHead>
-                  <TableHead>Description</TableHead>
-                  <TableHead>Required</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">q</TableCell>
-                  <TableCell>string</TableCell>
-                  <TableCell>Search query (player name)</TableCell>
-                  <TableCell>Yes</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">teamType</TableCell>
-                  <TableCell>
-                    <code className="text-sm">curr | class | allt</code>
-                  </TableCell>
-                  <TableCell>Filter by team type</TableCell>
-                  <TableCell>No</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">limit</TableCell>
-                  <TableCell>number</TableCell>
-                  <TableCell>Maximum results to return (max 50)</TableCell>
-                  <TableCell>No (default: 50)</TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </div>
-        </div>
-
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Example Request</h2>
-          <LanguageTabs
-            examples={{
-              javascript: `const response = await fetch(
-  'https://api.nba2kapi.com/api/players/search?q=lebron',
+const SAMPLES = [
   {
-    headers: {
-      'X-API-Key': 'your_api_key_here'
-    }
-  }
+    label: "cURL",
+    code: `curl 'https://api.nba2kapi.com/api/players/search?\\
+q=lebron' \\
+  -H 'X-API-Key: YOUR_KEY'`,
+  },
+  {
+    label: "JS",
+    code: `const res = await fetch(
+  'https://api.nba2kapi.com/api/players/search?q=lebron',
+  { headers: { 'X-API-Key': KEY } }
 );
+const { data } = await res.json();`,
+  },
+  {
+    label: "Python",
+    code: `import requests
 
-const data = await response.json();
-console.log(data.data); // Array of matching players`,
-              python: `import requests
+res = requests.get(
+  'https://api.nba2kapi.com/api/players/search',
+  params={'q': 'lebron'},
+  headers={'X-API-Key': KEY})
+data = res.json()['data']`,
+  },
+];
 
-response = requests.get(
-    'https://api.nba2kapi.com/api/players/search',
-    params={'q': 'lebron'},
-    headers={'X-API-Key': 'your_api_key_here'}
-)
-
-data = response.json()
-print(data['data'])  # Array of matching players`,
-              curl: `curl -X GET \\
-  'https://api.nba2kapi.com/api/players/search?q=lebron' \\
-  -H 'X-API-Key: your_api_key_here'`,
-            }}
-          />
-        </div>
-
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Example Response</h2>
-          <CodeBlock
-            code={`{
+const RESPONSE = `{
   "success": true,
   "data": [
     {
@@ -119,8 +49,8 @@ print(data['data'])  # Array of matching players`,
       "teamType": "curr",
       "overall": 97,
       "positions": ["SF", "PF"],
-      "playerImage": "https://...",
-      "teamImg": "https://..."
+      "playerImage": "https://…",
+      "teamImg": "https://…"
     }
   ],
   "meta": {
@@ -129,72 +59,61 @@ print(data['data'])  # Array of matching players`,
     "truncated": false,
     "timestamp": "2025-01-15T00:00:00.000Z"
   }
-}`}
-            language="json"
-          />
-        </div>
+}`;
 
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Search Tips</h2>
-          <div className="space-y-4">
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900">
-              <h4 className="mb-2 font-semibold">Partial Matching</h4>
-              <p className="mb-2 text-sm text-slate-600 dark:text-slate-400">
-                Search works with partial names. You don't need to type the full name.
-              </p>
-              <CodeBlock
-                code={`// All of these will find LeBron James:
-?q=lebron
-?q=lebron james
-?q=leb
-?q=james lebron`}
-                language="javascript"
-              />
-            </div>
+export default function SearchEndpointPage() {
+  return (
+    <DocColumns
+      rail={
+        <CodeRail samples={SAMPLES} response={RESPONSE} playgroundHref="/playground?search=lebron" />
+      }
+    >
+      <EndpointHeader path="/api/players/search" title="Search players">
+        <p className="m-0">
+          Find players by name with fuzzy matching — the endpoint behind autocomplete boxes,
+          type-to-search UIs, and Discord bot commands.
+        </p>
+      </EndpointHeader>
+      <AuthPill>REQUIRES X-API-KEY HEADER · 100 REQ/HR FREE</AuthPill>
 
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900">
-              <h4 className="mb-2 font-semibold">Case Insensitive</h4>
-              <p className="text-sm text-slate-600 dark:text-slate-400">
-                Search is case-insensitive. <code className="rounded bg-white px-1 text-xs dark:bg-slate-950">?q=LEBRON</code> and{" "}
-                <code className="rounded bg-white px-1 text-xs dark:bg-slate-950">?q=lebron</code> return the same results.
-              </p>
-            </div>
+      <DocLabel>QUERY PARAMETERS</DocLabel>
+      <ParamsTable
+        rows={[
+          {
+            name: "q",
+            type: "string · required",
+            desc: (
+              <>
+                The search query. Partial names work — <code>lebron</code>, <code>leb</code>, and{" "}
+                <code>james lebron</code> all find LeBron James.
+              </>
+            ),
+          },
+          {
+            name: "teamType",
+            type: "string",
+            desc: (
+              <>
+                Narrow to one era: <code>curr</code>, <code>class</code>, or <code>allt</code>.
+                E.g. <code>q=kobe&amp;teamType=class</code>.
+              </>
+            ),
+          },
+          {
+            name: "limit",
+            type: "number",
+            desc: <>Maximum results to return. Max 50, default 50.</>,
+          },
+        ]}
+      />
 
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900">
-              <h4 className="mb-2 font-semibold">Combine with Filters</h4>
-              <p className="mb-2 text-sm text-slate-600 dark:text-slate-400">
-                Narrow results by combining search with team type filters.
-              </p>
-              <CodeBlock
-                code={`// Search only current rosters
-?q=michael jordan&teamType=curr
-
-// Search classic teams
-?q=kobe&teamType=class`}
-                language="javascript"
-              />
-            </div>
-          </div>
-        </div>
-
-        <div className="space-y-4 rounded-lg border border-slate-200 bg-slate-50 p-6 dark:border-slate-800 dark:bg-slate-900">
-          <h3 className="text-lg font-semibold">Common Use Cases</h3>
-          <ul className="space-y-2 text-slate-600 dark:text-slate-400">
-            <li>
-              • Building an autocomplete search box
-            </li>
-            <li>
-              • Finding players by last name
-            </li>
-            <li>
-              • Implementing a "type to search" feature
-            </li>
-            <li>
-              • Creating Discord bot commands (/player search lebron)
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
+      <DocLabel>MATCHING BEHAVIOR</DocLabel>
+      <DocP>
+        Search is case-insensitive — <code>?q=LEBRON</code> and <code>?q=lebron</code> return the
+        same results — and word order doesn&apos;t matter. <code>meta.truncated</code> tells you
+        whether more matches exist beyond <code>limit</code>.
+      </DocP>
+      <FinePrint>RETURNS SUMMARY PLAYER OBJECTS · FETCH /API/PLAYERS/SLUG/:SLUG FOR FULL DETAIL.</FinePrint>
+    </DocColumns>
   );
 }

--- a/app/docs/endpoints/search/page.tsx
+++ b/app/docs/endpoints/search/page.tsx
@@ -65,7 +65,7 @@ export default function SearchEndpointPage() {
   return (
     <DocColumns
       rail={
-        <CodeRail samples={SAMPLES} response={RESPONSE} playgroundHref="/playground?search=lebron" />
+        <CodeRail samples={SAMPLES} response={RESPONSE} />
       }
     >
       <EndpointHeader path="/api/players/search" title="Search players">
@@ -74,7 +74,7 @@ export default function SearchEndpointPage() {
           type-to-search UIs, and Discord bot commands.
         </p>
       </EndpointHeader>
-      <AuthPill>REQUIRES X-API-KEY HEADER · 100 REQ/HR FREE</AuthPill>
+      <AuthPill>REQUIRES X-API-KEY HEADER · 500 REQ/HR FREE</AuthPill>
 
       <DocLabel>QUERY PARAMETERS</DocLabel>
       <ParamsTable

--- a/app/docs/endpoints/teams/page.tsx
+++ b/app/docs/endpoints/teams/page.tsx
@@ -81,7 +81,7 @@ export default function TeamsEndpointPage() {
           rosters.
         </p>
       </EndpointHeader>
-      <AuthPill>REQUIRES X-API-KEY HEADER · 100 REQ/HR FREE</AuthPill>
+      <AuthPill>REQUIRES X-API-KEY HEADER · 500 REQ/HR FREE</AuthPill>
 
       <DocLabel>QUERY PARAMETERS</DocLabel>
       <ParamsTable

--- a/app/docs/endpoints/teams/page.tsx
+++ b/app/docs/endpoints/teams/page.tsx
@@ -1,104 +1,59 @@
-import { Badge } from "@/components/ui/badge";
-import { CodeBlock } from "@/components/code-block";
-import { LanguageTabs } from "@/components/language-tabs";
-import { TryItLiveButton } from "@/components/try-it-live-button";
+"use client";
+
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+  AuthPill,
+  CodeRail,
+  DocColumns,
+  DocLabel,
+  DocP,
+  EndpointHeader,
+  FinePrint,
+  ParamsTable,
+} from "@/components/docs/kit";
 
-export default function TeamsEndpointPage() {
-  return (
-    <div className="space-y-8">
-      <div>
-        <div className="mb-4 flex items-center gap-3">
-          <Badge variant="outline" className="font-mono">
-            GET
-          </Badge>
-          <code className="text-2xl font-bold">/api/teams</code>
-        </div>
-        <p className="text-lg text-slate-600 dark:text-slate-400">
-          Retrieve a list of all NBA 2K teams with their rosters.
-        </p>
-        <div className="mt-4 flex gap-3">
-          <TryItLiveButton href="/teams" label="Browse All Teams" />
-          <TryItLiveButton
-            href="/teams?teamType=class"
-            label="View Classic Teams"
-            variant="secondary"
-          />
-        </div>
-      </div>
-
-      <div className="space-y-6">
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Query Parameters</h2>
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Parameter</TableHead>
-                  <TableHead>Type</TableHead>
-                  <TableHead>Description</TableHead>
-                  <TableHead>Default</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">teamType</TableCell>
-                  <TableCell>
-                    <code className="text-sm">curr | class | allt</code>
-                  </TableCell>
-                  <TableCell>Filter by team type (current, classic, all-time)</TableCell>
-                  <TableCell>
-                    <code className="text-sm">curr</code>
-                  </TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </div>
-        </div>
-
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Example Request</h2>
-          <LanguageTabs
-            examples={{
-              javascript: `const response = await fetch(
-  'https://api.nba2kapi.com/api/teams?teamType=curr',
+const SAMPLES = [
   {
-    headers: {
-      'X-API-Key': 'your_api_key_here'
-    }
-  }
-);
+    label: "cURL",
+    code: `curl 'https://api.nba2kapi.com/api/teams?era=curr' \\
+  -H 'X-API-Key: YOUR_KEY'
 
-const data = await response.json();
-console.log(data.data); // Array of all current NBA teams`,
-              python: `import requests
+# Roster: slug or full team name both work
+curl 'https://api.nba2kapi.com/api/teams/\\
+los-angeles-lakers/roster' \\
+  -H 'X-API-Key: YOUR_KEY'`,
+  },
+  {
+    label: "JS",
+    code: `const teams = await fetch(
+  'https://api.nba2kapi.com/api/teams?era=curr',
+  { headers: { 'X-API-Key': KEY } }
+).then(r => r.json());
 
-response = requests.get(
-    'https://api.nba2kapi.com/api/teams',
-    params={'teamType': 'curr'},
-    headers={'X-API-Key': 'your_api_key_here'}
-)
+// Roster: slug or full team name both work
+const roster = await fetch(
+  'https://api.nba2kapi.com/api/teams/' +
+  'los-angeles-lakers/roster',
+  { headers: { 'X-API-Key': KEY } }
+).then(r => r.json());`,
+  },
+  {
+    label: "Python",
+    code: `import requests
 
-data = response.json()
-print(data['data'])  # Array of all current NBA teams`,
-              curl: `curl -X GET \\
-  'https://api.nba2kapi.com/api/teams?teamType=curr' \\
-  -H 'X-API-Key: your_api_key_here'`,
-            }}
-          />
-        </div>
+teams = requests.get(
+  'https://api.nba2kapi.com/api/teams',
+  params={'era': 'curr'},
+  headers={'X-API-Key': KEY}).json()
 
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Example Response</h2>
-          <CodeBlock
-            code={`{
+# Roster: slug or full team name both work
+roster = requests.get(
+  'https://api.nba2kapi.com/api/teams/'
+  'los-angeles-lakers/roster',
+  headers={'X-API-Key': KEY}).json()`,
+  },
+];
+
+const RESPONSE = `{
   "success": true,
   "data": [
     {
@@ -113,72 +68,71 @@ print(data['data'])  # Array of all current NBA teams`,
       "playerCount": 16,
       "averageRating": 81.8
     },
-    // ... more teams
+    …
   ]
-}`}
-            language="json"
-          />
-        </div>
+}`;
 
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Get Team Roster</h2>
-          <p className="mb-4 text-slate-600 dark:text-slate-400">
-            To get a specific team's roster, use the team roster endpoint:
-          </p>
-          <LanguageTabs
-            examples={{
-              javascript: `const response = await fetch(
-  'https://api.nba2kapi.com/api/teams/Los%20Angeles%20Lakers/roster?teamType=curr',
-  {
-    headers: {
-      'X-API-Key': 'your_api_key_here'
-    }
-  }
-);
+export default function TeamsEndpointPage() {
+  return (
+    <DocColumns rail={<CodeRail samples={SAMPLES} response={RESPONSE} />}>
+      <EndpointHeader path="/api/teams" title="List teams">
+        <p className="m-0">
+          Every NBA 2K team with player count and average rating — current, classic, and all-time
+          rosters.
+        </p>
+      </EndpointHeader>
+      <AuthPill>REQUIRES X-API-KEY HEADER · 100 REQ/HR FREE</AuthPill>
 
-const data = await response.json();
-console.log(data.data); // Array of Lakers players`,
-              python: `import requests
+      <DocLabel>QUERY PARAMETERS</DocLabel>
+      <ParamsTable
+        rows={[
+          {
+            name: "era",
+            type: "string",
+            desc: (
+              <>
+                <code>curr</code> (default), <code>class</code>, <code>allt</code> — current NBA
+                teams, classic teams, or all-time teams. <code>teamType</code> is a supported
+                alias.
+              </>
+            ),
+          },
+        ]}
+      />
 
-response = requests.get(
-    'https://api.nba2kapi.com/api/teams/Los Angeles Lakers/roster',
-    params={'teamType': 'curr'},
-    headers={'X-API-Key': 'your_api_key_here'}
-)
-
-data = response.json()
-print(data['data'])  # Array of Lakers players`,
-              curl: `curl -X GET \\
-  'https://api.nba2kapi.com/api/teams/Los%20Angeles%20Lakers/roster?teamType=curr' \\
-  -H 'X-API-Key: your_api_key_here'`,
-            }}
-          />
-        </div>
-
-        <div className="space-y-4 rounded-lg border border-slate-200 bg-slate-50 p-6 dark:border-slate-800 dark:bg-slate-900">
-          <h3 className="text-lg font-semibold">Team Types</h3>
-          <ul className="space-y-2 text-slate-600 dark:text-slate-400">
-            <li>
-              <code className="mr-2 rounded bg-white px-1.5 py-0.5 text-sm dark:bg-slate-950">
-                curr
-              </code>
-              - Current NBA teams (2024-25 season)
-            </li>
-            <li>
-              <code className="mr-2 rounded bg-white px-1.5 py-0.5 text-sm dark:bg-slate-950">
-                class
-              </code>
-              - Classic teams (historic rosters)
-            </li>
-            <li>
-              <code className="mr-2 rounded bg-white px-1.5 py-0.5 text-sm dark:bg-slate-950">
-                allt
-              </code>
-              - All-time teams (greatest players franchise history)
-            </li>
-          </ul>
-        </div>
+      <DocLabel>GET /API/TEAMS/:TEAMNAME/ROSTER</DocLabel>
+      <DocP>
+        One team&apos;s full roster. <code>:teamName</code> accepts the full team name or its slug —{" "}
+        <code>Los Angeles Lakers</code> and <code>los-angeles-lakers</code> both resolve to the
+        same team.
+      </DocP>
+      <div className="mt-2.5">
+        <ParamsTable
+          rows={[
+            {
+              name: ":teamName",
+              type: "path · string",
+              desc: (
+                <>
+                  Full name or slug, e.g. <code>Los Angeles Lakers</code> or{" "}
+                  <code>los-angeles-lakers</code>.
+                </>
+              ),
+            },
+            {
+              name: "teamType",
+              type: "string · optional",
+              desc: (
+                <>
+                  <code>curr</code>, <code>class</code>, or <code>allt</code> to disambiguate
+                  franchises that exist in multiple eras.
+                </>
+              ),
+            },
+          ]}
+        />
       </div>
-    </div>
+      <FinePrint>ERAS: CURR = 2024-25 SEASON · CLASS = HISTORIC ROSTERS · ALLT = FRANCHISE GREATS.</FinePrint>
+    </DocColumns>
   );
 }

--- a/app/docs/errors/page.tsx
+++ b/app/docs/errors/page.tsx
@@ -89,12 +89,24 @@ export default function ErrorsPage() {
             ),
           },
           {
-            name: "INVALID_PARAMETERS",
+            name: "INVALID_PARAMETER",
             type: "400",
             desc: (
               <>
-                A query parameter is out of range, e.g. <code>limit</code> must be 1–100.{" "}
-                <code>details</code> names the offending parameter and constraint.
+                A parameter value is invalid, e.g. an unknown <code>sort</code> field or an
+                attribute bound outside 0–99. <code>details</code> names the constraint. Note:
+                values rejected by schema validation (bad enum, <code>limit</code> outside 1–100)
+                currently return a raw validation object rather than this envelope.
+              </>
+            ),
+          },
+          {
+            name: "UNKNOWN_PARAMETERS",
+            type: "400",
+            desc: (
+              <>
+                A query parameter this endpoint doesn&apos;t know. The response suggests the
+                closest valid parameter or endpoint.
               </>
             ),
           },

--- a/app/docs/errors/page.tsx
+++ b/app/docs/errors/page.tsx
@@ -1,316 +1,126 @@
-import { CodeBlock } from "@/components/code-block";
-import { AlertCircle } from "lucide-react";
+"use client";
+
+import Link from "next/link";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
+  DarkCode,
+  DocColumns,
+  DocH1,
+  DocLabel,
+  DocP,
+  FinePrint,
+  ParamsTable,
+} from "@/components/docs/kit";
 
-export default function ErrorsPage() {
-  return (
-    <div className="space-y-8">
-      <div>
-        <h1 className="mb-4 text-4xl font-bold">Error Handling</h1>
-        <p className="text-lg text-slate-600 dark:text-slate-400">
-          Understand error responses and how to handle them in your application.
-        </p>
-      </div>
-
-      <div className="space-y-6">
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Error Response Format</h2>
-          <p className="mb-4 text-slate-600 dark:text-slate-400">
-            All API errors follow a consistent JSON format:
-          </p>
-          <CodeBlock
-            code={`{
+const ENVELOPE = `{
   "success": false,
   "error": {
     "message": "A human-readable error message",
     "code": "ERROR_CODE",
-    "details": {} // Optional additional context
+    "details": {} // optional additional context
   }
-}`}
-            language="json"
-          />
-        </div>
+}`;
 
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">HTTP Status Codes</h2>
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Status Code</TableHead>
-                  <TableHead>Description</TableHead>
-                  <TableHead>Common Causes</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">200</TableCell>
-                  <TableCell>Success</TableCell>
-                  <TableCell>Request completed successfully</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">400</TableCell>
-                  <TableCell>Bad Request</TableCell>
-                  <TableCell>Invalid parameters or malformed request</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">401</TableCell>
-                  <TableCell>Unauthorized</TableCell>
-                  <TableCell>Missing or invalid API key</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">404</TableCell>
-                  <TableCell>Not Found</TableCell>
-                  <TableCell>Resource doesn't exist</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">429</TableCell>
-                  <TableCell>Too Many Requests</TableCell>
-                  <TableCell>Rate limit exceeded</TableCell>
-                </TableRow>
-                <TableRow>
-                  <TableCell className="font-mono text-sm">500</TableCell>
-                  <TableCell>Internal Server Error</TableCell>
-                  <TableCell>Server-side error occurred</TableCell>
-                </TableRow>
-              </TableBody>
-            </Table>
-          </div>
-        </div>
-
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Common Error Codes</h2>
-          <div className="space-y-4">
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900">
-              <h4 className="mb-2 font-mono text-sm font-semibold">MISSING_API_KEY</h4>
-              <p className="mb-3 text-sm text-slate-600 dark:text-slate-400">
-                No API key was provided in the request headers.
-              </p>
-              <CodeBlock
-                code={`{
-  "success": false,
-  "error": {
-    "message": "API key is required",
-    "code": "MISSING_API_KEY"
-  }
-}`}
-                language="json"
-              />
-              <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">
-                <strong>Solution:</strong> Include your API key in the X-API-Key header.
-              </p>
-            </div>
-
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900">
-              <h4 className="mb-2 font-mono text-sm font-semibold">INVALID_API_KEY</h4>
-              <p className="mb-3 text-sm text-slate-600 dark:text-slate-400">
-                The provided API key is invalid or expired.
-              </p>
-              <CodeBlock
-                code={`{
-  "success": false,
-  "error": {
-    "message": "Invalid API key",
-    "code": "INVALID_API_KEY"
-  }
-}`}
-                language="json"
-              />
-              <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">
-                <strong>Solution:</strong> Verify your API key is correct in your dashboard.
-              </p>
-            </div>
-
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900">
-              <h4 className="mb-2 font-mono text-sm font-semibold">RATE_LIMIT_EXCEEDED</h4>
-              <p className="mb-3 text-sm text-slate-600 dark:text-slate-400">
-                You've exceeded the rate limit for your API key.
-              </p>
-              <CodeBlock
-                code={`{
-  "success": false,
-  "error": {
-    "message": "Rate limit exceeded. Try again in 45 seconds.",
-    "code": "RATE_LIMIT_EXCEEDED",
-    "retryAfter": 45
-  }
-}`}
-                language="json"
-              />
-              <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">
-                <strong>Solution:</strong> Wait for the duration specified in retryAfter or implement exponential backoff.
-              </p>
-            </div>
-
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900">
-              <h4 className="mb-2 font-mono text-sm font-semibold">PLAYER_NOT_FOUND</h4>
-              <p className="mb-3 text-sm text-slate-600 dark:text-slate-400">
-                The requested player doesn't exist in the database.
-              </p>
-              <CodeBlock
-                code={`{
-  "success": false,
-  "error": {
-    "message": "Player not found",
-    "code": "PLAYER_NOT_FOUND"
-  }
-}`}
-                language="json"
-              />
-              <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">
-                <strong>Solution:</strong> Verify the player slug or ID is correct. Use the search endpoint to find players.
-              </p>
-            </div>
-
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900">
-              <h4 className="mb-2 font-mono text-sm font-semibold">INVALID_PARAMETERS</h4>
-              <p className="mb-3 text-sm text-slate-600 dark:text-slate-400">
-                One or more query parameters are invalid or out of range.
-              </p>
-              <CodeBlock
-                code={`{
-  "success": false,
-  "error": {
-    "message": "Invalid parameter: limit must be between 1 and 100",
-    "code": "INVALID_PARAMETERS",
-    "details": {
-      "parameter": "limit",
-      "value": 500,
-      "constraint": "Must be between 1 and 100"
-    }
-  }
-}`}
-                language="json"
-              />
-              <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">
-                <strong>Solution:</strong> Check the API documentation for valid parameter values and constraints.
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Error Handling Best Practices</h2>
-          <div className="space-y-4">
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900">
-              <h4 className="mb-2 font-semibold">Always Check Response Status</h4>
-              <p className="mb-3 text-sm text-slate-600 dark:text-slate-400">
-                Check both HTTP status codes and the success field in the response.
-              </p>
-              <CodeBlock
-                code={`const response = await fetch(url, { headers });
-
-if (!response.ok) {
-  const error = await response.json();
-  console.error('API Error:', error.error.message);
-
-  // Handle specific error codes
-  switch (error.error.code) {
-    case 'MISSING_API_KEY':
-    case 'INVALID_API_KEY':
-      // Update credentials
-      break;
-    case 'RATE_LIMIT_EXCEEDED':
-      // Wait and retry
-      break;
-    case 'PLAYER_NOT_FOUND':
-      // Show not found message
-      break;
-  }
-}`}
-                language="javascript"
-              />
-            </div>
-
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900">
-              <h4 className="mb-2 font-semibold">Implement Retry Logic</h4>
-              <p className="mb-3 text-sm text-slate-600 dark:text-slate-400">
-                Retry failed requests with exponential backoff for transient errors.
-              </p>
-              <CodeBlock
-                code={`async function fetchWithRetry(url, options, maxRetries = 3) {
+const RETRY_SNIPPET = `async function fetchWithRetry(url, options, maxRetries = 3) {
   for (let i = 0; i < maxRetries; i++) {
-    try {
-      const response = await fetch(url, options);
+    const response = await fetch(url, options);
 
-      if (response.ok) {
-        return await response.json();
-      }
+    if (response.ok) return response.json();
 
-      // Don't retry client errors (4xx except 429)
-      if (response.status >= 400 && response.status < 500 && response.status !== 429) {
-        throw new Error(\`Client error: \${response.status}\`);
-      }
-
-      // Exponential backoff
-      if (i < maxRetries - 1) {
-        const delay = Math.pow(2, i) * 1000;
-        await new Promise(resolve => setTimeout(resolve, delay));
-      }
-    } catch (error) {
-      if (i === maxRetries - 1) throw error;
+    // Don't retry client errors (4xx except 429)
+    if (response.status >= 400 &&
+        response.status < 500 &&
+        response.status !== 429) {
+      throw new Error(\`Client error: \${response.status}\`);
     }
+
+    // Exponential backoff: 1s, 2s, 4s
+    const delay = Math.pow(2, i) * 1000;
+    await new Promise(resolve => setTimeout(resolve, delay));
   }
-}`}
-                language="javascript"
-              />
-            </div>
+  throw new Error('Max retries exceeded');
+}`;
 
-            <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-900">
-              <h4 className="mb-2 font-semibold">Log Errors for Debugging</h4>
-              <p className="mb-3 text-sm text-slate-600 dark:text-slate-400">
-                Keep detailed logs of API errors to help diagnose issues.
-              </p>
-              <CodeBlock
-                code={`try {
-  const data = await fetchPlayer('lebron-james');
-} catch (error) {
-  // Log full error details
-  console.error('Failed to fetch player:', {
-    timestamp: new Date().toISOString(),
-    endpoint: '/api/players/lebron-james',
-    error: error.message,
-    code: error.code,
-    details: error.details
-  });
-
-  // Show user-friendly message
-  showErrorMessage('Unable to load player data. Please try again.');
-}`}
-                language="javascript"
-              />
-            </div>
-          </div>
+export default function ErrorsPage() {
+  return (
+    <DocColumns
+      rail={
+        <div className="flex flex-col gap-2.5">
+          <DarkCode title="ERROR ENVELOPE">{ENVELOPE}</DarkCode>
+          <DarkCode title="RETRY LOGIC">{RETRY_SNIPPET}</DarkCode>
         </div>
+      }
+    >
+      <DocH1>Error handling</DocH1>
+      <DocP>
+        Every error is the same shape: HTTP status plus a JSON envelope with a{" "}
+        <code>message</code>, a stable <code>code</code>, and optional <code>details</code>. Check
+        both the status and the <code>success</code> field.
+      </DocP>
 
-        <div className="flex gap-3 rounded-lg border border-yellow-200 bg-yellow-50 p-4 dark:border-yellow-900 dark:bg-yellow-950">
-          <AlertCircle className="h-5 w-5 shrink-0 text-yellow-600 dark:text-yellow-400" />
-          <div>
-            <h4 className="mb-1 font-semibold text-yellow-900 dark:text-yellow-100">
-              Need Help with an Error?
-            </h4>
-            <p className="text-sm text-yellow-700 dark:text-yellow-300">
-              If you're experiencing persistent errors or need clarification about an error code, please open an issue on{" "}
-              <a
-                href="https://github.com/wkoverfield/nba2kapi/issues"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-medium underline"
-              >
-                GitHub
-              </a>{" "}
-              with details about the error, your request, and any relevant logs.
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
+      <DocLabel>ERROR CODES</DocLabel>
+      <ParamsTable
+        rows={[
+          {
+            name: "MISSING_API_KEY",
+            type: "401",
+            desc: (
+              <>
+                No key in the request headers. Add <code>X-API-Key</code>.
+              </>
+            ),
+          },
+          {
+            name: "INVALID_API_KEY",
+            type: "401",
+            desc: (
+              <>
+                Key is invalid or expired. Verify it in your <Link href="/dashboard">dashboard</Link>.
+              </>
+            ),
+          },
+          {
+            name: "PLAYER_NOT_FOUND",
+            type: "404",
+            desc: (
+              <>
+                No such player. Check the slug or find them via{" "}
+                <Link href="/docs/endpoints/search">/api/players/search</Link>.
+              </>
+            ),
+          },
+          {
+            name: "INVALID_PARAMETERS",
+            type: "400",
+            desc: (
+              <>
+                A query parameter is out of range, e.g. <code>limit</code> must be 1–100.{" "}
+                <code>details</code> names the offending parameter and constraint.
+              </>
+            ),
+          },
+          {
+            name: "RATE_LIMIT_EXCEEDED",
+            type: "429",
+            desc: (
+              <>
+                Over your limit. Wait <code>retryAfter</code> seconds — see{" "}
+                <Link href="/docs/rate-limits">rate limits</Link>.
+              </>
+            ),
+          },
+        ]}
+      />
+
+      <DocLabel>WHEN TO RETRY</DocLabel>
+      <DocP>
+        Retry <code>429</code> and <code>5xx</code> with exponential backoff (snippet on the
+        right). Never retry other <code>4xx</code> errors — they mean the request itself is wrong:
+        fix the key, the slug, or the parameter. Log the <code>code</code>, <code>message</code>,
+        and <code>details</code> when things fail; they pinpoint the problem.
+      </DocP>
+      <FinePrint>
+        STUCK ON AN ERROR? OPEN A GITHUB ISSUE (WKOVERFIELD/NBA2KAPI) WITH THE REQUEST AND RESPONSE.
+      </FinePrint>
+    </DocColumns>
   );
 }

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -1,8 +1,16 @@
-import { DocsSidebar } from "@/components/docs-sidebar";
+"use client";
 
-const docsNavigation = [
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { TopNav } from "@/components/chrome/top-nav";
+import { FooterStrip } from "@/components/chrome/footer-strip";
+import { API_KEY_STORAGE_KEY } from "@/lib/constants";
+import { cn } from "@/lib/utils";
+
+const DOCS_NAV = [
   {
-    title: "Getting Started",
+    title: "GETTING STARTED",
     items: [
       { title: "Introduction", href: "/docs" },
       { title: "Quickstart", href: "/docs/quickstart" },
@@ -10,7 +18,7 @@ const docsNavigation = [
     ],
   },
   {
-    title: "API Reference",
+    title: "API REFERENCE",
     items: [
       { title: "Players", href: "/docs/endpoints/players" },
       { title: "Teams", href: "/docs/endpoints/teams" },
@@ -18,27 +26,66 @@ const docsNavigation = [
     ],
   },
   {
-    title: "Guides",
+    title: "GUIDES",
     items: [
-      { title: "Rate Limits", href: "/docs/rate-limits" },
-      { title: "Error Handling", href: "/docs/errors" },
+      { title: "Rate limits", href: "/docs/rate-limits" },
+      { title: "Error handling", href: "/docs/errors" },
     ],
   },
 ];
 
-export default function DocsLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function DocsLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const [hasApiKey, setHasApiKey] = useState(false);
+
+  useEffect(() => {
+    setHasApiKey(!!localStorage.getItem(API_KEY_STORAGE_KEY));
+  }, []);
+
   return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="flex gap-8">
-        <DocsSidebar sections={docsNavigation} />
-        <main className="min-w-0 flex-1">
-          <div className="mx-auto max-w-3xl">{children}</div>
+    <div className="min-h-screen bg-[#faf9f5] font-body text-[#1a1918]">
+      <div className="border-b border-[#f1efe8]">
+        <TopNav hasApiKey={hasApiKey} />
+      </div>
+
+      <div className="mx-auto flex max-w-[1360px] flex-wrap items-start gap-[clamp(20px,3vw,32px)] px-[clamp(20px,4vw,48px)] pt-[26px] pb-14">
+        {/* Sidebar tree */}
+        <div className="flex min-w-[160px] flex-[0_1_190px] flex-col gap-5 animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none">
+          {DOCS_NAV.map((section) => (
+            <div key={section.title}>
+              <div className="mb-2 font-plex text-[8.5px] tracking-[0.12em] text-[#b5b0a1]">
+                {section.title}
+              </div>
+              <div className="flex flex-col gap-0.5">
+                {section.items.map((item) => (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={cn(
+                      "rounded-lg px-2.5 py-[5px] text-[13px] no-underline transition-colors duration-150",
+                      pathname === item.href
+                        ? "bg-[#f1efe8] font-semibold text-[#1a1918]"
+                        : "font-medium text-[#57534a] hover:bg-[#f1efe8]"
+                    )}
+                  >
+                    {item.title}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Page body */}
+        <main
+          className="min-w-0 flex-[1_1_640px] animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
+          style={{ animationDelay: "60ms" }}
+        >
+          {children}
         </main>
       </div>
+
+      <FooterStrip />
     </div>
   );
 }

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,148 +1,68 @@
+"use client";
+
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { ArrowRight, Database, Zap, Shield } from "lucide-react";
+import { DocColumns, DocH1, DocLabel, DocP, FinePrint, ParamsTable } from "@/components/docs/kit";
 
 export default function DocsIntroduction() {
   return (
-    <div className="space-y-8">
-      <div>
-        <h1 className="mb-4 text-4xl font-bold">Introduction</h1>
-        <p className="text-lg text-slate-600 dark:text-slate-400">
-          Welcome to the NBA 2K Ratings API documentation. Access comprehensive NBA 2K player data
-          through a simple REST API.
-        </p>
-      </div>
+    <DocColumns>
+      <DocH1>Introduction</DocH1>
+      <DocP>
+        The NBA 2K Ratings API is programmatic access to player ratings from the NBA 2K video game
+        series — data scraped from{" "}
+        <a href="https://2kratings.com" target="_blank" rel="noopener noreferrer">
+          2kratings.com
+        </a>{" "}
+        and served through a clean REST interface. Basketball games, Discord bots, ratings
+        analysis: one API key, JSON out.
+      </DocP>
 
-      <div className="grid gap-6 md:grid-cols-3">
-        <Card>
-          <CardHeader>
-            <Database className="mb-2 h-8 w-8 text-primary" />
-            <CardTitle className="text-base">Comprehensive Data</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <CardDescription>
-              Access 40+ player attributes, badges, team rosters, and historical data
-            </CardDescription>
-          </CardContent>
-        </Card>
+      <DocLabel>WHAT&apos;S IN THE DATA</DocLabel>
+      <ParamsTable
+        rows={[
+          {
+            name: "Player attributes",
+            type: "40+ per player",
+            desc: (
+              <>
+                Overall rating, positions, height, weight, archetype, and individual stats across
+                shooting, finishing, playmaking, defense, and athleticism.
+              </>
+            ),
+          },
+          {
+            name: "Badges",
+            type: "with tiers",
+            desc: <>Complete badge information: Bronze, Silver, Gold, Hall of Fame, Legend.</>,
+          },
+          {
+            name: "Team rosters",
+            type: "3 eras",
+            desc: <>Current NBA teams, classic teams, and all-time teams.</>,
+          },
+          {
+            name: "Player images",
+            type: "URLs",
+            desc: <>Headshot URLs for each player, plus team logos.</>,
+          },
+        ]}
+      />
+      <FinePrint>159MS AVERAGE RESPONSE TIME · INTELLIGENT CACHING · 99%+ UPTIME.</FinePrint>
 
-        <Card>
-          <CardHeader>
-            <Zap className="mb-2 h-8 w-8 text-primary" />
-            <CardTitle className="text-base">Fast & Reliable</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <CardDescription>
-              159ms average response time with intelligent caching and 99%+ uptime
-            </CardDescription>
-          </CardContent>
-        </Card>
+      <DocLabel>WHO IT&apos;S FOR</DocLabel>
+      <DocP>
+        Indie game developers building basketball or fantasy tools, Discord bot creators adding 2K
+        stats commands, data analysts researching rating trends, and web developers building
+        2K-related sites. Every request authenticates with an API key and is rate limited to
+        protect against abuse.
+      </DocP>
 
-        <Card>
-          <CardHeader>
-            <Shield className="mb-2 h-8 w-8 text-primary" />
-            <CardTitle className="text-base">Secure</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <CardDescription>
-              API key authentication with rate limiting to protect against abuse
-            </CardDescription>
-          </CardContent>
-        </Card>
-      </div>
-
-      <div className="space-y-4">
-        <h2 className="text-2xl font-bold">What is this API?</h2>
-        <p className="text-slate-600 dark:text-slate-400">
-          The NBA 2K Ratings API provides programmatic access to player ratings and statistics from
-          the NBA 2K video game series. Our API scrapes data from{" "}
-          <a
-            href="https://2kratings.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="font-medium text-primary hover:underline"
-          >
-            2kratings.com
-          </a>{" "}
-          and makes it available through a clean REST interface.
-        </p>
-        <p className="text-slate-600 dark:text-slate-400">
-          Whether you're building a basketball game, creating a Discord bot, or analyzing player
-          stats, this API gives you instant access to detailed NBA 2K player data.
-        </p>
-      </div>
-
-      <div className="space-y-4">
-        <h2 className="text-2xl font-bold">What data is available?</h2>
-        <ul className="space-y-2 text-slate-600 dark:text-slate-400">
-          <li className="flex items-start gap-2">
-            <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-primary" />
-            <span>
-              <strong>Player Attributes:</strong> Overall rating, position, height, weight,
-              archetype, and 40+ individual stats (shooting, finishing, playmaking, defense,
-              athleticism)
-            </span>
-          </li>
-          <li className="flex items-start gap-2">
-            <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-primary" />
-            <span>
-              <strong>Badges:</strong> Complete badge information with tiers (Bronze, Silver, Gold,
-              Hall of Fame, Legend)
-            </span>
-          </li>
-          <li className="flex items-start gap-2">
-            <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-primary" />
-            <span>
-              <strong>Team Rosters:</strong> Current NBA teams, classic teams, and all-time teams
-            </span>
-          </li>
-          <li className="flex items-start gap-2">
-            <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-primary" />
-            <span>
-              <strong>Player Images:</strong> Headshot URLs for each player
-            </span>
-          </li>
-        </ul>
-      </div>
-
-      <div className="space-y-4">
-        <h2 className="text-2xl font-bold">Who is this for?</h2>
-        <p className="text-slate-600 dark:text-slate-400">
-          This API is designed for developers, data analysts, and basketball gaming enthusiasts who
-          need programmatic access to NBA 2K data:
-        </p>
-        <ul className="space-y-2 text-slate-600 dark:text-slate-400">
-          <li className="flex items-start gap-2">
-            <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-primary" />
-            <span>Indie game developers building basketball games or fantasy tools</span>
-          </li>
-          <li className="flex items-start gap-2">
-            <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-primary" />
-            <span>Discord bot creators wanting to add NBA 2K stats commands</span>
-          </li>
-          <li className="flex items-start gap-2">
-            <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-primary" />
-            <span>Data analysts researching player ratings and trends</span>
-          </li>
-          <li className="flex items-start gap-2">
-            <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-primary" />
-            <span>Web developers creating 2K-related websites and tools</span>
-          </li>
-        </ul>
-      </div>
-
-      <div className="flex gap-4 border-t pt-8">
-        <Button asChild>
-          <Link href="/docs/quickstart">
-            Get Started
-            <ArrowRight className="ml-2 h-4 w-4" />
-          </Link>
-        </Button>
-        <Button variant="outline" asChild>
-          <Link href="/docs/endpoints/players">View API Reference</Link>
-        </Button>
-      </div>
-    </div>
+      <DocLabel>START HERE</DocLabel>
+      <DocP>
+        The <Link href="/docs/quickstart">quickstart</Link> takes you from key to first response in
+        under 5 minutes. Not ready to write code? Explore the data visually in the{" "}
+        <Link href="/playground">playground</Link>.
+      </DocP>
+    </DocColumns>
   );
 }

--- a/app/docs/quickstart/page.tsx
+++ b/app/docs/quickstart/page.tsx
@@ -1,94 +1,48 @@
+"use client";
+
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { LanguageTabs } from "@/components/language-tabs";
-import { TryItLiveButton } from "@/components/try-it-live-button";
-import { ArrowRight } from "lucide-react";
+import { CodeRail, DocColumns, DocH1, DocLabel, DocP, FinePrint } from "@/components/docs/kit";
 
-export default function QuickstartPage() {
-  return (
-    <div className="space-y-8">
-      <div>
-        <h1 className="mb-4 text-4xl font-bold">Quickstart</h1>
-        <p className="text-lg text-slate-600 dark:text-slate-400">
-          Get up and running with the NBA 2K Ratings API in under 5 minutes.
-        </p>
-      </div>
-
-      <div className="space-y-6">
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">1. Get your API key</h2>
-          <p className="mb-4 text-slate-600 dark:text-slate-400">
-            First, you'll need an API key to authenticate your requests. Click the button below to
-            get started:
-          </p>
-          <Button asChild>
-            <Link href="/dashboard">Get API Key</Link>
-          </Button>
-        </div>
-
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">2. Make your first request</h2>
-          <p className="mb-4 text-slate-600 dark:text-slate-400">
-            Once you have your API key, you can start making requests. Here's how to fetch a
-            player's data:
-          </p>
-          <LanguageTabs
-            examples={{
-              javascript: `const response = await fetch(
-  'https://api.nba2kapi.com/api/players/slug/lebron-james',
+const SAMPLES = [
   {
-    headers: {
-      'X-API-Key': 'your_api_key_here'
-    }
-  }
+    label: "cURL",
+    code: `curl 'https://api.nba2kapi.com/api/players/slug/lebron-james' \\
+  -H 'X-API-Key: your_api_key_here'
+
+# Players on multiple teams (like Michael Jordan):
+# add ?teamType=class&team='95-'96 Bulls`,
+  },
+  {
+    label: "JS",
+    code: `const res = await fetch(
+  'https://api.nba2kapi.com/api/players/slug/lebron-james',
+  { headers: { 'X-API-Key': 'your_api_key_here' } }
 );
+const { success, data } = await res.json();
 
-const data = await response.json();
+if (success) {
+  console.log(data.name);      // "LeBron James"
+  console.log(data.overall);   // 97
+  console.log(data.positions); // ["SF", "PF"]
+  console.log(data.team);      // "Los Angeles Lakers"
+}`,
+  },
+  {
+    label: "Python",
+    code: `import requests
 
-if (data.success) {
-  console.log(data.data.name);      // "LeBron James"
-  console.log(data.data.overall);   // 97
-  console.log(data.data.positions); // ["SF", "PF"]
-  console.log(data.data.team);      // "Los Angeles Lakers"
-}
-
-// For players on multiple teams (like Michael Jordan), use team param:
-// /api/players/slug/michael-jordan?teamType=class&team='95-'96 Bulls`,
-              python: `import requests
-
-response = requests.get(
-    'https://api.nba2kapi.com/api/players/slug/lebron-james',
-    headers={'X-API-Key': 'your_api_key_here'}
-)
-
-data = response.json()
+res = requests.get(
+  'https://api.nba2kapi.com/api/players/slug/lebron-james',
+  headers={'X-API-Key': 'your_api_key_here'})
+data = res.json()
 
 if data['success']:
     print(data['data']['name'])     # "LeBron James"
-    print(data['data']['overall'])  # 97
-    print(data['data']['positions']) # ["SF", "PF"]
-    print(data['data']['team'])     # "Los Angeles Lakers"
+    print(data['data']['overall'])  # 97`,
+  },
+];
 
-# For players on multiple teams, add team param:
-# ?teamType=class&team='95-'96 Bulls`,
-              curl: `curl -X GET \\
-  'https://api.nba2kapi.com/api/players/slug/lebron-james' \\
-  -H 'X-API-Key: your_api_key_here'
-
-# For players on multiple teams (like Michael Jordan):
-# Add ?teamType=class&team='95-'96 Bulls`,
-            }}
-          />
-        </div>
-
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">3. Understanding the response</h2>
-          <p className="mb-4 text-slate-600 dark:text-slate-400">
-            All API responses follow a consistent structure:
-          </p>
-          <LanguageTabs
-            examples={{
-              javascript: `{
+const RESPONSE = `{
   "success": true,
   "data": {
     "_id": "abc123",
@@ -100,123 +54,52 @@ if data['success']:
     "positions": ["SF", "PF"],
     "height": "6'9\\"",
     "weight": "250 lbs",
-    "playerImage": "https://...",
-    "teamImg": "https://...",
-    // Detailed attributes
+    "playerImage": "https://…",
+    "teamImg": "https://…",
     "closeShot": 92,
     "midRangeShot": 88,
     "threePointShot": 44,
-    // ... 40+ more attributes
+    … 40+ more attributes,
     "lastUpdated": "2025-01-15T00:00:00.000Z"
   }
-}`,
-            }}
-          />
-        </div>
+}`;
 
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">4. Try other endpoints</h2>
-          <p className="mb-4 text-slate-600 dark:text-slate-400">
-            Now that you've made your first request, explore other endpoints:
-          </p>
-          <ul className="space-y-2 text-slate-600 dark:text-slate-400">
-            <li className="flex items-start gap-2">
-              <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-primary" />
-              <span>
-                <Link
-                  href="/docs/endpoints/players"
-                  className="font-medium text-primary hover:underline"
-                >
-                  GET /api/players
-                </Link>{" "}
-                - List all players with filtering
-              </span>
-            </li>
-            <li className="flex items-start gap-2">
-              <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-primary" />
-              <span>
-                <Link
-                  href="/docs/endpoints/teams"
-                  className="font-medium text-primary hover:underline"
-                >
-                  GET /api/teams
-                </Link>{" "}
-                - Get all team rosters
-              </span>
-            </li>
-            <li className="flex items-start gap-2">
-              <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-primary" />
-              <span>
-                <Link
-                  href="/docs/endpoints/search"
-                  className="font-medium text-primary hover:underline"
-                >
-                  GET /api/players/search
-                </Link>{" "}
-                - Search for players by name
-              </span>
-            </li>
-          </ul>
-        </div>
+export default function QuickstartPage() {
+  return (
+    <DocColumns rail={<CodeRail samples={SAMPLES} response={RESPONSE} playgroundHref="/playground" />}>
+      <DocH1>Quickstart</DocH1>
+      <DocP>From zero to first response in under 5 minutes.</DocP>
 
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">5. Explore visually in the playground</h2>
-          <p className="mb-4 text-slate-600 dark:text-slate-400">
-            Not ready to write code yet? Try our interactive playground to explore player data
-            visually with advanced filtering and search.
-          </p>
-          <div className="flex gap-3">
-            <TryItLiveButton href="/playground" label="Explore All Players" />
-            <TryItLiveButton
-              href="/teams"
-              label="Browse Teams"
-              variant="secondary"
-            />
-          </div>
-        </div>
+      <DocLabel>STEP 1 · GET YOUR API KEY</DocLabel>
+      <DocP>
+        Every request authenticates with an API key. Grab yours from the{" "}
+        <Link href="/dashboard">dashboard</Link> — no password, the key is the login.
+      </DocP>
 
-        <div className="space-y-4 rounded-lg border border-slate-200 bg-slate-50 p-6 dark:border-slate-800 dark:bg-slate-900">
-          <h3 className="text-lg font-semibold">Next steps</h3>
-          <ul className="space-y-2 text-slate-600 dark:text-slate-400">
-            <li className="flex items-start gap-2">
-              <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-primary" />
-              <span>
-                Learn about{" "}
-                <Link
-                  href="/docs/authentication"
-                  className="font-medium text-primary hover:underline"
-                >
-                  authentication best practices
-                </Link>
-              </span>
-            </li>
-            <li className="flex items-start gap-2">
-              <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-primary" />
-              <span>
-                Explore the full{" "}
-                <Link
-                  href="/docs/endpoints/players"
-                  className="font-medium text-primary hover:underline"
-                >
-                  API reference
-                </Link>
-              </span>
-            </li>
-            <li className="flex items-start gap-2">
-              <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-primary" />
-              <span>
-                Understand{" "}
-                <Link
-                  href="/docs/rate-limits"
-                  className="font-medium text-primary hover:underline"
-                >
-                  rate limits
-                </Link>
-              </span>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
+      <DocLabel>STEP 2 · MAKE YOUR FIRST REQUEST</DocLabel>
+      <DocP>
+        Pass the key in the <code>X-API-Key</code> header. The samples on the right fetch one
+        player by slug. For players who exist on multiple teams (like Michael Jordan), add{" "}
+        <code>?teamType=class&amp;team=&apos;95-&apos;96 Bulls</code> to pick the version you want.
+      </DocP>
+
+      <DocLabel>STEP 3 · READ THE RESPONSE</DocLabel>
+      <DocP>
+        Every response follows the same envelope: <code>success</code> plus <code>data</code>. A
+        player object carries name, slug, team, overall, positions, and 40+ individual attributes.
+        The full response is shown on the right.
+      </DocP>
+
+      <DocLabel>WHERE TO NEXT</DocLabel>
+      <DocP>
+        <Link href="/docs/endpoints/players">GET /api/players</Link> lists everyone with filtering,{" "}
+        <Link href="/docs/endpoints/teams">GET /api/teams</Link> serves rosters, and{" "}
+        <Link href="/docs/endpoints/search">GET /api/players/search</Link> finds players by name.
+        Read up on <Link href="/docs/authentication">authentication</Link> and{" "}
+        <Link href="/docs/rate-limits">rate limits</Link>, or skip the code entirely and explore in
+        the <Link href="/playground">playground</Link>.
+      </DocP>
+      <FinePrint>ALL SAMPLES USE THE LIVE API AT API.NBA2KAPI.COM.</FinePrint>
+    </DocColumns>
   );
 }

--- a/app/docs/rate-limits/page.tsx
+++ b/app/docs/rate-limits/page.tsx
@@ -1,113 +1,35 @@
-import { CodeBlock } from "@/components/code-block";
-import { AlertCircle, CheckCircle2 } from "lucide-react";
+"use client";
 
-export default function RateLimitsPage() {
-  return (
-    <div className="space-y-8">
-      <div>
-        <h1 className="mb-4 text-4xl font-bold">Rate Limits</h1>
-        <p className="text-lg text-slate-600 dark:text-slate-400">
-          Understand how rate limiting works and how to handle rate limit errors.
-        </p>
-      </div>
+import {
+  DarkCode,
+  DocColumns,
+  DocH1,
+  DocLabel,
+  DocP,
+  FinePrint,
+  ParamsTable,
+} from "@/components/docs/kit";
 
-      <div className="space-y-6">
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Current Limits</h2>
-          <div className="rounded-lg border border-slate-200 bg-slate-50 p-6 dark:border-slate-800 dark:bg-slate-900">
-            <div className="grid gap-6 md:grid-cols-2">
-              <div>
-                <h4 className="mb-2 text-lg font-semibold">Requests per Hour</h4>
-                <p className="text-3xl font-bold text-primary">100</p>
-                <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
-                  Maximum requests allowed per API key per hour
-                </p>
-              </div>
-              <div>
-                <h4 className="mb-2 text-lg font-semibold">Requests per Minute</h4>
-                <p className="text-3xl font-bold text-primary">20</p>
-                <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
-                  Maximum requests allowed per API key per minute
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Rate Limit Headers</h2>
-          <p className="mb-4 text-slate-600 dark:text-slate-400">
-            Every API response includes headers that tell you about your current rate limit status:
-          </p>
-          <CodeBlock
-            code={`X-RateLimit-Limit: 100
+const HEADERS_SAMPLE = `X-RateLimit-Limit: 100
 X-RateLimit-Remaining: 95
-X-RateLimit-Reset: 1642521600`}
-            language="bash"
-          />
-          <div className="mt-4 space-y-2 text-sm text-slate-600 dark:text-slate-400">
-            <p>
-              <code className="rounded bg-slate-100 px-1.5 py-0.5 dark:bg-slate-800">X-RateLimit-Limit</code>: Maximum requests allowed in the current window
-            </p>
-            <p>
-              <code className="rounded bg-slate-100 px-1.5 py-0.5 dark:bg-slate-800">X-RateLimit-Remaining</code>: Number of requests remaining in the current window
-            </p>
-            <p>
-              <code className="rounded bg-slate-100 px-1.5 py-0.5 dark:bg-slate-800">X-RateLimit-Reset</code>: Unix timestamp when the rate limit resets
-            </p>
-          </div>
-        </div>
+X-RateLimit-Reset: 1642521600`;
 
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Handling Rate Limit Errors</h2>
-          <p className="mb-4 text-slate-600 dark:text-slate-400">
-            When you exceed the rate limit, you'll receive a 429 Too Many Requests response:
-          </p>
-          <CodeBlock
-            code={`{
+const RESPONSE_429 = `{
   "success": false,
   "error": {
-    "message": "You have exceeded your rate limit. Please try again in 45 seconds",
+    "message": "You have exceeded your rate limit.
+      Please try again in 45 seconds",
     "code": "RATE_LIMIT_EXCEEDED",
     "details": {
       "limit": 100,
       "reset": "2025-01-15T00:45:00.000Z",
-      "retryAfter": 45,
-      "message": "You have exceeded your rate limit. Please try again in 45 seconds"
+      "retryAfter": 45
     },
     "timestamp": "2025-01-15T00:00:00.000Z"
   }
-}`}
-            language="json"
-          />
-        </div>
+}`;
 
-        <div>
-          <h2 className="mb-3 text-2xl font-bold">Best Practices</h2>
-          <div className="space-y-4">
-            <div className="flex gap-3 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-900 dark:bg-green-950">
-              <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-              <div>
-                <h4 className="mb-1 font-semibold text-green-900 dark:text-green-100">
-                  Monitor rate limit headers
-                </h4>
-                <p className="text-sm text-green-700 dark:text-green-300">
-                  Check the <code className="rounded bg-green-100 px-1 dark:bg-green-950">X-RateLimit-Remaining</code> header and slow down before hitting the limit.
-                </p>
-              </div>
-            </div>
-
-            <div className="flex gap-3 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-900 dark:bg-green-950">
-              <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-              <div>
-                <h4 className="mb-1 font-semibold text-green-900 dark:text-green-100">
-                  Implement exponential backoff
-                </h4>
-                <p className="mb-2 text-sm text-green-700 dark:text-green-300">
-                  If you receive a 429 error, wait before retrying. Use exponential backoff for repeated failures.
-                </p>
-                <CodeBlock
-                  code={`async function fetchWithRetry(url, options, maxRetries = 3) {
+const RETRY_SNIPPET = `async function fetchWithRetry(url, options, maxRetries = 3) {
   for (let i = 0; i < maxRetries; i++) {
     const response = await fetch(url, options);
 
@@ -121,55 +43,75 @@ X-RateLimit-Reset: 1642521600`}
   }
 
   throw new Error('Max retries exceeded');
-}`}
-                  language="javascript"
-                  className="mt-2"
-                />
-              </div>
-            </div>
+}`;
 
-            <div className="flex gap-3 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-900 dark:bg-green-950">
-              <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
-              <div>
-                <h4 className="mb-1 font-semibold text-green-900 dark:text-green-100">
-                  Cache responses
-                </h4>
-                <p className="text-sm text-green-700 dark:text-green-300">
-                  Store frequently accessed data locally to reduce API calls. Player ratings don't change often.
-                </p>
-              </div>
-            </div>
-
-            <div className="flex gap-3 rounded-lg border border-yellow-200 bg-yellow-50 p-4 dark:border-yellow-900 dark:bg-yellow-950">
-              <AlertCircle className="h-5 w-5 shrink-0 text-yellow-600 dark:text-yellow-400" />
-              <div>
-                <h4 className="mb-1 font-semibold text-yellow-900 dark:text-yellow-100">
-                  Don't make parallel requests unnecessarily
-                </h4>
-                <p className="text-sm text-yellow-700 dark:text-yellow-300">
-                  Making many simultaneous requests will quickly exhaust your rate limit. Batch requests when possible.
-                </p>
-              </div>
-            </div>
-          </div>
+export default function RateLimitsPage() {
+  return (
+    <DocColumns
+      rail={
+        <div className="flex flex-col gap-2.5">
+          <DarkCode title="RESPONSE HEADERS">{HEADERS_SAMPLE}</DarkCode>
+          <DarkCode title="429 TOO MANY REQUESTS">{RESPONSE_429}</DarkCode>
+          <DarkCode title="RETRY WITH BACKOFF">{RETRY_SNIPPET}</DarkCode>
         </div>
+      }
+    >
+      <DocH1>Rate limits</DocH1>
+      <DocP>
+        Limits apply per API key across two windows. Blow either one and you get a{" "}
+        <code>429</code> until it resets.
+      </DocP>
 
-        <div className="space-y-4 rounded-lg border border-slate-200 bg-slate-50 p-6 dark:border-slate-800 dark:bg-slate-900">
-          <h3 className="text-lg font-semibold">Need higher limits?</h3>
-          <p className="text-slate-600 dark:text-slate-400">
-            The current rate limits are designed to be generous for most use cases. If you have a legitimate need for higher limits, please reach out via{" "}
-            <a
-              href="https://github.com/wkoverfield/nba2kapi/issues"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-medium text-primary hover:underline"
-            >
-              GitHub Issues
-            </a>{" "}
-            with details about your use case.
-          </p>
-        </div>
+      <DocLabel>CURRENT LIMITS</DocLabel>
+      <ParamsTable
+        rows={[
+          {
+            name: "100 / hour",
+            type: "per API key",
+            desc: <>Maximum requests allowed per API key per hour.</>,
+          },
+          {
+            name: "20 / minute",
+            type: "per API key",
+            desc: <>Maximum requests allowed per API key per minute.</>,
+          },
+        ]}
+      />
+
+      <DocLabel>RATE LIMIT HEADERS</DocLabel>
+      <DocP>Every response tells you where you stand:</DocP>
+      <div className="mt-2.5">
+        <ParamsTable
+          rows={[
+            {
+              name: "X-RateLimit-Limit",
+              type: "number",
+              desc: <>Maximum requests allowed in the current window.</>,
+            },
+            {
+              name: "X-RateLimit-Remaining",
+              type: "number",
+              desc: <>Requests remaining in the current window.</>,
+            },
+            {
+              name: "X-RateLimit-Reset",
+              type: "unix timestamp",
+              desc: <>When the current window resets.</>,
+            },
+          ]}
+        />
       </div>
-    </div>
+
+      <DocLabel>HANDLING 429S</DocLabel>
+      <DocP>
+        Watch <code>X-RateLimit-Remaining</code> and slow down before you hit zero. On a{" "}
+        <code>429</code>, wait <code>retryAfter</code> seconds (or use exponential backoff, right).
+        Cache responses locally — ratings don&apos;t change often — and avoid bursts of parallel
+        requests; batch where you can.
+      </DocP>
+      <FinePrint>
+        NEED HIGHER LIMITS? OPEN A GITHUB ISSUE (WKOVERFIELD/NBA2KAPI) WITH YOUR USE CASE.
+      </FinePrint>
+    </DocColumns>
   );
 }

--- a/app/docs/rate-limits/page.tsx
+++ b/app/docs/rate-limits/page.tsx
@@ -10,9 +10,9 @@ import {
   ParamsTable,
 } from "@/components/docs/kit";
 
-const HEADERS_SAMPLE = `X-RateLimit-Limit: 100
-X-RateLimit-Remaining: 95
-X-RateLimit-Reset: 1642521600`;
+const HEADERS_SAMPLE = `X-RateLimit-Limit: 500
+X-RateLimit-Remaining: 463
+X-RateLimit-Reset: 2026-01-15T01:00:00.000Z`;
 
 const RESPONSE_429 = `{
   "success": false,
@@ -21,7 +21,7 @@ const RESPONSE_429 = `{
       Please try again in 45 seconds",
     "code": "RATE_LIMIT_EXCEEDED",
     "details": {
-      "limit": 100,
+      "limit": 500,
       "reset": "2025-01-15T00:45:00.000Z",
       "retryAfter": 45
     },
@@ -58,22 +58,22 @@ export default function RateLimitsPage() {
     >
       <DocH1>Rate limits</DocH1>
       <DocP>
-        Limits apply per API key across two windows. Blow either one and you get a{" "}
-        <code>429</code> until it resets.
+        One window: requests per API key per hour. Blow through it and you get a{" "}
+        <code>429</code> until the hour resets.
       </DocP>
 
       <DocLabel>CURRENT LIMITS</DocLabel>
       <ParamsTable
         rows={[
           {
-            name: "100 / hour",
+            name: "500 / hour",
             type: "per API key",
-            desc: <>Maximum requests allowed per API key per hour.</>,
-          },
-          {
-            name: "20 / minute",
-            type: "per API key",
-            desc: <>Maximum requests allowed per API key per minute.</>,
+            desc: (
+              <>
+                Free-tier default, set per key at creation — the dashboard and{" "}
+                <code>X-RateLimit-Limit</code> always show your key&apos;s real number.
+              </>
+            ),
           },
         ]}
       />
@@ -95,8 +95,13 @@ export default function RateLimitsPage() {
             },
             {
               name: "X-RateLimit-Reset",
-              type: "unix timestamp",
-              desc: <>When the current window resets.</>,
+              type: "ISO-8601 string",
+              desc: (
+                <>
+                  When the current window resets, e.g.{" "}
+                  <code>2026-01-15T01:00:00.000Z</code>.
+                </>
+              ),
             },
           ]}
         />

--- a/components/chrome/key-dialog.tsx
+++ b/components/chrome/key-dialog.tsx
@@ -82,7 +82,7 @@ export function KeyDialog({ open, onOpenChange, onSuccess }: KeyDialogProps) {
                 Get your key
               </Dialog.Title>
               <Dialog.Description className="mt-1.5 mb-0 text-[13px] leading-[1.5] text-[#57534a]">
-                Free. 100 requests an hour. No credit card, no password — the key is your login.
+                Free. 500 requests an hour. No credit card, no password — the key is your login.
               </Dialog.Description>
               <form onSubmit={handleSubmit} className="mt-[18px] flex flex-col gap-3">
                 <div>

--- a/components/docs/kit.tsx
+++ b/components/docs/kit.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Lock, Play } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/** Docs building blocks for the paper/editorial reskin. */
+
+export function MethodBadge({ method = "GET" }: { method?: string }) {
+  return (
+    <span className="rounded-[6px] bg-[#eaf5ee] px-[9px] py-1 font-plex text-[10px] font-bold text-[#0a7f3f]">
+      {method}
+    </span>
+  );
+}
+
+export function EndpointHeader({
+  method = "GET",
+  path,
+  title,
+  children,
+}: {
+  method?: string;
+  path: string;
+  title: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-2.5">
+        <MethodBadge method={method} />
+        <span className="font-plex text-[16px] font-semibold">{path}</span>
+      </div>
+      <h1 className="mt-3.5 mb-0 font-display text-[clamp(24px,2.6vw,28px)] font-extrabold tracking-[-0.03em]">
+        {title}
+      </h1>
+      {children && (
+        <div className="mt-2 text-[14px] leading-[1.6] text-[#57534a] [&_a]:font-semibold [&_a]:text-[#1a1918]">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function AuthPill({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mt-3 inline-flex items-center gap-2 rounded-full border border-[#e5e2da] bg-white px-3.5 py-1.5">
+      <Lock className="h-[11px] w-[11px] text-[#9a6700]" strokeWidth={2} />
+      <span className="font-plex text-[9.5px] text-[#57534a]">{children}</span>
+    </div>
+  );
+}
+
+export function DocLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mt-[26px] mb-2.5 font-plex text-[9.5px] tracking-[0.12em] text-[#8a8577]">
+      {children}
+    </div>
+  );
+}
+
+export function DocH1({ children }: { children: React.ReactNode }) {
+  return (
+    <h1 className="m-0 font-display text-[clamp(24px,2.6vw,28px)] font-extrabold tracking-[-0.03em]">
+      {children}
+    </h1>
+  );
+}
+
+export function DocP({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mt-2 mb-0 text-[14px] leading-[1.65] text-[#57534a] [&_a]:font-semibold [&_a]:text-[#1a1918] [&_code]:rounded-[5px] [&_code]:border [&_code]:border-[#e5e2da] [&_code]:bg-white [&_code]:px-[5px] [&_code]:py-px [&_code]:font-plex [&_code]:text-[11.5px] [&_code]:text-[#1a1918]">
+      {children}
+    </p>
+  );
+}
+
+export function FinePrint({ children }: { children: React.ReactNode }) {
+  return <p className="mt-3.5 mb-0 font-plex text-[8.5px] text-[#b5b0a1]">{children}</p>;
+}
+
+export type ParamRow = {
+  name: string;
+  type: string;
+  desc: React.ReactNode;
+  isNew?: boolean;
+};
+
+export function ParamsTable({ rows }: { rows: ParamRow[] }) {
+  return (
+    <div className="overflow-hidden rounded-[14px] border border-[#e5e2da] bg-white">
+      {rows.map((p) => (
+        <div
+          key={p.name}
+          className="grid grid-cols-[minmax(140px,200px)_1fr] gap-3.5 border-b border-[#f6f4ee] px-[18px] py-3 last:border-b-0"
+        >
+          <div>
+            <div className="flex flex-wrap items-center gap-[7px]">
+              <span className="font-plex text-[11px] font-bold break-all">{p.name}</span>
+              {p.isNew && (
+                <span className="rounded-[4px] bg-[#f6e9c8] px-[5px] py-0.5 font-plex text-[7px] font-bold tracking-[0.08em] text-[#9a6700]">
+                  NEW
+                </span>
+              )}
+            </div>
+            <div className="mt-[3px] font-plex text-[8.5px] text-[#b5b0a1]">{p.type}</div>
+          </div>
+          <div className="m-0 text-[12.5px] leading-[1.55] text-[#57534a] [&_code]:font-plex [&_code]:text-[11px] [&_code]:text-[#1a1918]">
+            {p.desc}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function DarkCode({
+  title,
+  right,
+  children,
+}: {
+  title?: string;
+  right?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="overflow-hidden rounded-[14px] bg-[#1a1918]">
+      {(title || right) && (
+        <div className="flex items-center justify-between border-b border-white/10 px-4 py-2">
+          <span className="font-plex text-[9px] tracking-[0.1em] text-white/60">{title}</span>
+          {right}
+        </div>
+      )}
+      <pre className="m-0 overflow-x-auto px-4 py-3.5 font-plex text-[10px] leading-[1.7] text-white/85">
+        {children}
+      </pre>
+    </div>
+  );
+}
+
+export function CodeRail({
+  samples,
+  response,
+  playgroundHref,
+}: {
+  samples: { label: string; code: string }[];
+  response?: React.ReactNode;
+  playgroundHref?: string;
+}) {
+  const [lang, setLang] = useState(0);
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    navigator.clipboard.writeText(samples[lang].code).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1400);
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="overflow-hidden rounded-[14px] bg-[#1a1918]">
+        <div className="flex items-center border-b border-white/10">
+          {samples.map((s, i) => (
+            <button
+              key={s.label}
+              type="button"
+              onClick={() => setLang(i)}
+              className={cn(
+                "cursor-pointer px-[13px] py-2 font-plex text-[9px] transition-colors duration-150 select-none hover:text-[#faf9f5]",
+                i === lang ? "bg-white/12 text-[#faf9f5]" : "text-white/55"
+              )}
+            >
+              {s.label}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={copy}
+            className="ml-auto cursor-pointer px-[13px] py-2 font-plex text-[8.5px] text-white/60 transition-colors duration-150 hover:text-[#faf9f5]"
+          >
+            {copied ? "COPIED ✓" : "COPY"}
+          </button>
+        </div>
+        <pre className="m-0 overflow-x-auto px-4 py-3.5 font-plex text-[10px] leading-[1.7] text-white/85">
+          {samples[lang].code}
+        </pre>
+      </div>
+
+      {response && (
+        <DarkCode
+          title="RESPONSE"
+          right={<span className="font-plex text-[8.5px] text-[#6ee7a0]">200 OK</span>}
+        >
+          {response}
+        </DarkCode>
+      )}
+
+      {playgroundHref && (
+        <Link
+          href={playgroundHref}
+          className="flex items-center justify-center gap-2 rounded-full border border-[#1a1918] bg-white py-2.5 text-[12.5px] font-semibold text-[#1a1918] no-underline transition-[background,transform] duration-150 hover:bg-[#f1efe8] active:scale-[0.98] motion-reduce:transition-none"
+        >
+          <Play className="h-3 w-3" strokeWidth={2} />
+          Run this in the playground
+        </Link>
+      )}
+    </div>
+  );
+}
+
+/** Two-column page body: prose (left) + sticky code rail (right). */
+export function DocColumns({
+  children,
+  rail,
+}: {
+  children: React.ReactNode;
+  rail?: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-wrap items-start gap-[clamp(20px,3vw,32px)]">
+      <div className="min-w-[min(100%,380px)] flex-[1_1_420px]">{children}</div>
+      {rail && (
+        <div className="sticky top-5 max-w-[420px] min-w-[min(100%,320px)] flex-[1_1_340px]">
+          {rail}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/legacy-chrome.tsx
+++ b/components/legacy-chrome.tsx
@@ -7,8 +7,8 @@ import { Footer } from "@/components/footer";
 // Routes that have been migrated to the new (paper/editorial) design render
 // their own chrome (TopNav / SiteFooter) inside the page, so the legacy
 // header/footer must not double up on them.
-const RESKINNED_ROUTES = new Set(["/", "/playground", "/teams", "/lineups", "/dashboard"]);
-const RESKINNED_PREFIXES = ["/teams/", "/players/"];
+const RESKINNED_ROUTES = new Set(["/", "/playground", "/teams", "/lineups", "/dashboard", "/docs"]);
+const RESKINNED_PREFIXES = ["/teams/", "/players/", "/docs/"];
 
 function isReskinned(pathname: string) {
   return RESKINNED_ROUTES.has(pathname) || RESKINNED_PREFIXES.some((p) => pathname.startsWith(p));


### PR DESCRIPTION
## What

Screen 8 of 8: **Final Docs.dc.html**. The design defines the shell (sidebar tree / prose + params / sticky code rail) and one reference-page pattern; this PR builds that shell as the docs layout, extracts the pattern into a reusable kit, and converts all 8 existing docs pages onto it.

## How

- `components/docs/kit.tsx` carries the whole pattern: endpoint header with method badge, auth pill, params table with the amber NEW tags, the dark code rail (cURL/JS/Python tabs, copy, live-styled response card, "Run this in the playground"), and prose primitives.
- The flagship `GET /api/players` page matches the mock and documents the API additions shipped earlier in this reskin (`era=all`, position groups, `{attr}_gte/_lte`, `sort`, `fields`) — the sample query deep-links into the playground pre-filled.
- The other 7 pages keep their factual content (limits, error codes, samples) but ported to the kit, with facts updated where the API changed (teams `era` alias, roster endpoint accepting slugs).
- Docs sidebar is the design's tree with active-pill state; legacy DocsSidebar and the shadcn tables/cards are no longer referenced by any docs route.

## Verified

Build + tsc clean; browser QA: flagship page matches the mock (three columns, tabs switch, params table), all 7 converted pages render on the new kit with no legacy card markup, sidebar active states correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)