### PR TITLE
feat: global ⌘K command palette + name search everywhere

### DIFF
--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -171,15 +171,16 @@ type QueryState = {
   sortKey: SortKey;
   sortDir: -1 | 1;
   team: string | null;
+  search: string | null;
 };
 
 function stateFromParams(sp: URLSearchParams): QueryState {
   // Pristine /playground gets the design's showcase defaults. A URL that
   // carries any query param is a deep link — unspecified slots must stay
   // wide open ("anyone" / "any era" / "any 3PT") so the link isn't narrowed.
-  const isDeepLink = ["position", "era", "three_ball_gte", "sort", "team"].some((k) => sp.has(k));
+  const isDeepLink = ["position", "era", "three_ball_gte", "sort", "team", "search"].some((k) => sp.has(k));
   if (!isDeepLink) {
-    return { pos: 0, era: 0, three: 1, sortKey: "overall", sortDir: -1, team: null };
+    return { pos: 0, era: 0, three: 1, sortKey: "overall", sortDir: -1, team: null, search: null };
   }
   const posIdx = POS_SLOTS.findIndex((s) => s.param === sp.get("position"));
   const eraIdx = ERA_SLOTS.findIndex((s) => s.param === sp.get("era"));
@@ -197,6 +198,7 @@ function stateFromParams(sp: URLSearchParams): QueryState {
     sortKey,
     sortDir: sortDir === "asc" ? 1 : -1,
     team: sp.get("team"),
+    search: sp.get("search"),
   };
 }
 
@@ -207,6 +209,7 @@ function paramsFromState(s: QueryState): string {
   params.set("era", ERA_SLOTS[s.era].param);
   if (THREE_SLOTS[s.three].v > 0) params.set("three_ball_gte", String(THREE_SLOTS[s.three].v));
   if (s.team) params.set("team", s.team);
+  if (s.search) params.set("search", s.search);
   params.set("sort", `${SORT_URL_NAMES[s.sortKey]}:${s.sortDir === -1 ? "desc" : "asc"}`);
   return params.toString();
 }
@@ -248,6 +251,7 @@ function Playground() {
         if (era !== "all" && p.teamType !== era) return false;
         if (minThree > 0 && (p.threePointShot === null || p.threePointShot < minThree)) return false;
         if (q.team && p.team !== q.team) return false;
+        if (q.search && !p.name.toLowerCase().includes(q.search.toLowerCase())) return false;
         return true;
       })
       .sort((a, b) => {
@@ -338,7 +342,7 @@ function Playground() {
   };
 
   const applySaved = (s: (typeof SAVED_QUERIES)[number]) =>
-    setQ({ pos: s.pos, era: s.era, three: s.three, sortKey: s.sortKey, sortDir: -1, team: s.team });
+    setQ({ pos: s.pos, era: s.era, three: s.three, sortKey: s.sortKey, sortDir: -1, team: s.team, search: null });
 
   const monoHead = "font-plex text-[8.5px] tracking-[0.08em]";
   const rowGrid =
@@ -397,6 +401,16 @@ function Playground() {
               title="Clear team filter"
             >
               TEAM: {q.team.toUpperCase()} ✕
+            </button>
+          )}
+          {q.search && (
+            <button
+              type="button"
+              onClick={() => setQ((s) => ({ ...s, search: null }))}
+              className="cursor-pointer rounded-full border border-[#e5e2da] bg-white px-2.5 py-0.5 font-plex text-[9px] tracking-[0.08em] text-[#57534a] hover:border-[#1a1918]"
+              title="Clear name search"
+            >
+              NAME: &quot;{q.search.toUpperCase()}&quot; ✕
             </button>
           )}
         </span>

--- a/components/chrome/command-palette.tsx
+++ b/components/chrome/command-palette.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Search } from "lucide-react";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { Headshot } from "@/components/ui/headshot";
+import { getRatingClasses } from "@/lib/rating-colors";
+import { getTeamAbbreviation, getTeamConference, formatTeamShortName } from "@/lib/team-abbr";
+import { cn } from "@/lib/utils";
+
+type TeamType = "curr" | "class" | "allt";
+
+type PoolPlayer = {
+  name: string;
+  slug: string;
+  team: string;
+  teamType: TeamType;
+  positions: string[];
+  overall: number;
+  playerImage: string | null;
+};
+
+type Result =
+  | { kind: "player"; key: string; name: string; meta: string; href: string; player: PoolPlayer }
+  | { kind: "team"; key: string; name: string; meta: string; href: string; abbr: string }
+  | { kind: "query"; key: string; name: string; meta: string; href: string };
+
+type Group = { label: string; items: Result[] };
+
+function playerResult(p: PoolPlayer): Result {
+  const era = p.teamType === "curr" ? "" : p.teamType === "class" ? " · CLASSIC" : " · ALL-TIME";
+  return {
+    kind: "player",
+    key: `p:${p.slug}:${p.teamType}:${p.team}`,
+    name: p.name,
+    meta: `${p.positions.join("/")} · ${getTeamAbbreviation(p.team)} · ${p.overall}${era}`,
+    href: `/players/${p.slug}?type=${p.teamType}&team=${encodeURIComponent(p.team)}`,
+    player: p,
+  };
+}
+
+export function CommandPalette({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const router = useRouter();
+  const [q, setQ] = useState("");
+  const [sel, setSel] = useState(0);
+  const [everOpened, setEverOpened] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setEverOpened(true);
+      setQ("");
+      setSel(0);
+    }
+  }, [open]);
+
+  // Lazy: the dataset is only subscribed after the palette first opens.
+  const players = useQuery(
+    api.players.getPlaygroundPlayers,
+    everOpened ? {} : "skip"
+  ) as PoolPlayer[] | undefined;
+
+  const teams = useMemo(() => {
+    if (!players) return [];
+    const byTeam = new Map<string, { team: string; teamType: TeamType; sum: number; n: number }>();
+    for (const p of players) {
+      const key = `${p.team}:${p.teamType}`;
+      const t = byTeam.get(key) ?? { team: p.team, teamType: p.teamType, sum: 0, n: 0 };
+      t.sum += p.overall;
+      t.n++;
+      byTeam.set(key, t);
+    }
+    const all = [...byTeam.values()].map((t) => ({
+      ...t,
+      avg: Math.round((t.sum / t.n) * 10) / 10,
+    }));
+    // Rank within each era by roster strength (matches the Board)
+    const rank = new Map<string, number>();
+    for (const era of ["curr", "class", "allt"] as const) {
+      all
+        .filter((t) => t.teamType === era)
+        .sort((a, b) => b.avg - a.avg)
+        .forEach((t, i) => rank.set(`${t.team}:${t.teamType}`, i + 1));
+    }
+    return all.map((t): Result => {
+      const conf = getTeamConference(t.team);
+      return {
+        kind: "team",
+        key: `t:${t.team}:${t.teamType}`,
+        name: formatTeamShortName(t.team, t.teamType),
+        meta: `#${rank.get(`${t.team}:${t.teamType}`)}${conf ? ` · ${conf}` : ""} · ${t.avg.toFixed(1)} AVG${t.teamType === "curr" ? "" : t.teamType === "class" ? " · CLASSIC" : " · ALL-TIME"}`,
+        href: `/teams/${t.team.toLowerCase().replace(/[^a-z0-9]+/g, "-")}?type=${t.teamType}`,
+        abbr: getTeamAbbreviation(t.team),
+      };
+    });
+  }, [players]);
+
+  const groups: Group[] = useMemo(() => {
+    const query = q.trim().toLowerCase();
+    const out: Group[] = [];
+
+    if (players) {
+      const matchedPlayers = query
+        ? players
+            .filter((p) => p.name.toLowerCase().includes(query))
+            .sort((a, b) => b.overall - a.overall)
+            .slice(0, 8)
+        : [...players]
+            .filter((p) => p.teamType === "curr")
+            .sort((a, b) => b.overall - a.overall)
+            .slice(0, 5);
+      if (matchedPlayers.length) {
+        out.push({
+          label: query ? "PLAYERS" : "TOP PLAYERS",
+          items: matchedPlayers.map(playerResult),
+        });
+      }
+
+      const matchedTeams = query
+        ? teams.filter((t) => t.name.toLowerCase().includes(query)).slice(0, 6)
+        : teams
+            .filter((t) => t.kind === "team" && t.meta.startsWith("#") && t.href.includes("type=curr"))
+            .sort((a, b) => Number(a.meta.slice(1).split(" ")[0]) - Number(b.meta.slice(1).split(" ")[0]))
+            .slice(0, 3);
+      if (matchedTeams.length) out.push({ label: "TEAMS", items: matchedTeams });
+    }
+
+    out.push({
+      label: "RUN AS QUERY",
+      items: [
+        {
+          kind: "query",
+          key: "q",
+          name: query ? `Show me everyone matching "${q.trim()}"` : "Open the query playground",
+          meta: query
+            ? `GET /api/players?search=${encodeURIComponent(q.trim())}&era=all`
+            : "Build a query as a sentence",
+          href: query
+            ? `/playground?search=${encodeURIComponent(q.trim())}&era=all`
+            : "/playground",
+        },
+      ],
+    });
+    return out;
+  }, [players, teams, q]);
+
+  const flat = useMemo(() => groups.flatMap((g) => g.items), [groups]);
+
+  useEffect(() => setSel(0), [q]);
+
+  const activate = (index: number) => {
+    const item = flat[index];
+    if (!item) return;
+    onOpenChange(false);
+    router.push(item.href);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSel((s) => Math.min(s + 1, flat.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSel((s) => Math.max(s - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      activate(sel);
+    }
+  };
+
+  // Keep the selected row in view
+  useEffect(() => {
+    const el = listRef.current?.querySelector(`[data-idx="${sel}"]`);
+    el?.scrollIntoView({ block: "nearest" });
+  }, [sel]);
+
+  let runningIndex = -1;
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-[rgba(26,25,24,0.35)] backdrop-blur-[2px]" />
+        <Dialog.Content
+          onKeyDown={onKeyDown}
+          className="fixed top-[12%] left-1/2 z-50 w-[min(640px,calc(100vw-32px))] -translate-x-1/2 overflow-hidden rounded-[18px] border border-[#e5e2da] bg-white font-body shadow-[0_40px_80px_-24px_rgba(26,25,24,0.5)] animate-[pop-in_220ms_cubic-bezier(0.23,1,0.32,1)_both] focus:outline-none motion-reduce:animate-none"
+        >
+          <Dialog.Title className="sr-only">Search players, teams, and queries</Dialog.Title>
+          <div className="flex items-center gap-3 border-b border-[#f1efe8] px-5 py-[15px]">
+            <Search className="h-4 w-4 text-[#8a8577]" strokeWidth={2} />
+            <input
+              autoFocus
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              placeholder="Search players, teams…"
+              className="flex-1 border-none bg-transparent font-body text-[16px] text-[#1a1918] outline-none placeholder:text-[#b5b0a1]"
+            />
+            <span className="font-plex text-[9px] text-[#b5b0a1]">ESC TO CLOSE</span>
+          </div>
+
+          <div ref={listRef} className="max-h-[56vh] overflow-y-auto px-2 pt-2 pb-1.5">
+            {groups.map((g) => (
+              <div key={g.label}>
+                <div className="px-3.5 pt-2 pb-1 font-plex text-[8.5px] tracking-[0.12em] text-[#b5b0a1]">
+                  {g.label}
+                </div>
+                {g.items.map((item) => {
+                  runningIndex++;
+                  const index = runningIndex;
+                  const active = index === sel;
+                  return (
+                    <div
+                      key={item.key}
+                      data-idx={index}
+                      onMouseMove={() => setSel(index)}
+                      onClick={() => activate(index)}
+                      className={cn(
+                        "flex cursor-pointer items-center gap-3 rounded-[10px] px-3.5 py-[9px]",
+                        active && "bg-[#f1efe8]"
+                      )}
+                    >
+                      {item.kind === "player" ? (
+                        <Headshot src={item.player.playerImage} name={item.name} size={30} />
+                      ) : item.kind === "team" ? (
+                        <span className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-full bg-[#f1efe8] font-display text-[10px] font-extrabold text-[#57534a]">
+                          {item.abbr}
+                        </span>
+                      ) : (
+                        <span className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-lg bg-[#1a1918]">
+                          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#faf9f5" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                            <polyline points="4 17 10 11 4 5" />
+                            <line x1="12" x2="20" y1="19" y2="19" />
+                          </svg>
+                        </span>
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <p className="m-0 overflow-hidden text-[13.5px] font-semibold text-ellipsis whitespace-nowrap text-[#1a1918]">
+                          {item.name}
+                        </p>
+                        <p className="mt-px mb-0 overflow-hidden font-plex text-[8.5px] text-ellipsis whitespace-nowrap text-[#8a8577]">
+                          {item.meta}
+                        </p>
+                      </div>
+                      {item.kind === "query" ? (
+                        <span className="font-plex text-[8px] text-[#b5b0a1]">→ PLAYGROUND</span>
+                      ) : (
+                        active && <span className="font-plex text-[9px] text-[#b5b0a1]">↵</span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+            {everOpened && !players && (
+              <div className="px-3.5 py-6 text-center font-plex text-[9px] tracking-[0.08em] text-[#b5b0a1]">
+                LOADING THE DATASET…
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3.5 border-t border-[#f1efe8] bg-[#faf9f5] px-5 py-2.5 font-plex text-[8.5px] text-[#b5b0a1]">
+            <span>↑↓ NAVIGATE</span>
+            <span>↵ OPEN</span>
+            <span className="ml-auto">SEARCHES ALL 3 ERAS</span>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/components/chrome/command-palette.tsx
+++ b/components/chrome/command-palette.tsx
@@ -88,13 +88,14 @@ export function CommandPalette({
     for (const era of ["curr", "class", "allt"] as const) {
       all
         .filter((t) => t.teamType === era)
-        .sort((a, b) => b.avg - a.avg)
+        .sort((a, b) => b.avg - a.avg || a.team.localeCompare(b.team))
         .forEach((t, i) => rank.set(`${t.team}:${t.teamType}`, i + 1));
     }
-    return all.map((t): Result => {
+    return all.map((t): Result & { teamType: TeamType } => {
       const conf = getTeamConference(t.team);
       return {
         kind: "team",
+        teamType: t.teamType,
         key: `t:${t.team}:${t.teamType}`,
         name: formatTeamShortName(t.team, t.teamType),
         meta: `#${rank.get(`${t.team}:${t.teamType}`)}${conf ? ` · ${conf}` : ""} · ${t.avg.toFixed(1)} AVG${t.teamType === "curr" ? "" : t.teamType === "class" ? " · CLASSIC" : " · ALL-TIME"}`,
@@ -128,7 +129,7 @@ export function CommandPalette({
       const matchedTeams = query
         ? teams.filter((t) => t.name.toLowerCase().includes(query)).slice(0, 6)
         : teams
-            .filter((t) => t.kind === "team" && t.meta.startsWith("#") && t.href.includes("type=curr"))
+            .filter((t) => t.teamType === "curr")
             .sort((a, b) => Number(a.meta.slice(1).split(" ")[0]) - Number(b.meta.slice(1).split(" ")[0]))
             .slice(0, 3);
       if (matchedTeams.length) out.push({ label: "TEAMS", items: matchedTeams });

--- a/components/chrome/top-nav.tsx
+++ b/components/chrome/top-nav.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname } from "next/navigation";
 import { Search } from "lucide-react";
+import { CommandPalette } from "@/components/chrome/command-palette";
 import { cn } from "@/lib/utils";
 
 const NAV_LINKS = [
@@ -82,26 +83,20 @@ export function TopNav({
 }: TopNavProps) {
   const ctaLabel = hasApiKey ? "View dashboard" : "Get an API key";
   const pathname = usePathname();
-  const router = useRouter();
   const stars = useGitHubStars(GITHUB_REPO);
+  const [paletteOpen, setPaletteOpen] = useState(false);
 
-  // Until the global command palette ships, ⌘K and the search pill route to
-  // the Playground, where full player search lives.
+  // ⌘K / Ctrl+K opens the global command palette (a modal, so it's safe to
+  // fire even while an input has focus).
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey) || e.key !== "k") return;
-      // Don't steal the shortcut while the user is typing (e.g. the
-      // registration dialog's form fields).
-      const el = document.activeElement as HTMLElement | null;
-      if (el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable)) {
-        return;
-      }
+      if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== "k") return;
       e.preventDefault();
-      router.push("/playground");
+      setPaletteOpen((o) => !o);
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [router]);
+  }, []);
 
   const ctaClasses =
     "rounded-full bg-[#1a1918] px-5 py-2.5 text-[13.5px] font-semibold text-[#faf9f5] no-underline transition-[background,transform] duration-150 ease-out hover:bg-[#333] active:scale-[0.97] motion-reduce:transition-none";
@@ -141,8 +136,8 @@ export function TopNav({
       <div className="flex items-center gap-2.5">
         <button
           type="button"
-          onClick={() => router.push("/playground")}
-          title="Search everything — players, teams, badges"
+          onClick={() => setPaletteOpen(true)}
+          title="Search everything — players, teams, queries"
           className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-[#e5e2da] bg-white px-3.5 py-[9px] transition-[border-color,transform] duration-150 ease-out hover:border-[#1a1918] active:scale-[0.97] motion-reduce:transition-none"
         >
           <Search className="h-[13px] w-[13px] text-[#57534a]" strokeWidth={2} />
@@ -179,6 +174,8 @@ export function TopNav({
           </Link>
         )}
       </div>
+
+      <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
     </div>
   );
 }

--- a/convex/_validation.ts
+++ b/convex/_validation.ts
@@ -204,6 +204,7 @@ export const VALID_PARAMS_BY_ENDPOINT: Record<string, Set<string>> = {
   "/api/players": new Set([
     "teamType",
     "era",
+    "search",
     "team",
     "minRating",
     "maxRating",

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -694,6 +694,7 @@ app.get("/api/players",
     // era supersedes teamType; "all" merges current + classic + all-time.
     era: z.enum(["all", "curr", "class", "allt"]).optional(),
     team: z.string().optional(),
+    search: z.string().max(80).optional(),
     minRating: z.coerce.number().min(0).max(99).optional(),
     maxRating: z.coerce.number().min(0).max(99).optional(),
     position: z.string().optional(),
@@ -727,6 +728,7 @@ app.get("/api/players",
       if (era !== "all") queryArgs.teamType = era;
 
       if (params.team) queryArgs.teams = [params.team];
+      if (params.search) queryArgs.search = params.search;
       if (params.minRating !== undefined) queryArgs.minOverall = params.minRating;
       if (params.maxRating !== undefined) queryArgs.maxOverall = params.maxRating;
       if (params.position) {


### PR DESCRIPTION
## What

The last piece of the handoff: the shared ⌘K command palette, as a real component on every reskinned page, plus the name-search plumbing that makes its "run as query" handoff honest.

## How

- Palette opens from ⌘K/Ctrl+K or the nav search pill. Searches players and teams across all three eras (dataset lazy-subscribes on first open, so pages pay nothing until you use it). Grouped results with keyboard nav and hover selection; default state shows top current players and the top of the board.
- Player results carry era-aware metas ("PG · GSW · 97 · CLASSIC") and open the exact era+team version of the dossier; team results show live board rank + conference + roster avg.
- "Run as query" navigates to `/playground?search=<q>&era=all`. To support that honestly, the playground gained a name filter (URL param + clearable NAME chip in the meta strip) and `GET /api/players` now accepts `search=` (wired to the filter `getAllFiltered` already had), so the request URL the playground displays is a real call.
- Badges search from the mock is deferred: there's no badge surface to land a result on yet, and the badge junction table is unpopulated on dev. Noted for a follow-up.

## Verified

Build + tsc clean; browser QA: ⌘K opens on any reskinned page, "curry" surfaces all five Curry versions plus Dell Curry, Enter opens the right dossier (`?type=allt&team=All-Time...`), run-as-query lands on the playground with 7 matches, a clearable chip, and `/api/players?era=all&search=curry&sort=overall:desc` displayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)