### PR TITLE
fix: taste round 1 — card bg, copy affordances, kbd cycling, tooltips, palette logos

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -204,10 +204,19 @@ export default function Home() {
               >
                 {hasApiKey ? "View dashboard" : "Get an API key"}
               </button>
-              <div className="rounded-full border border-[#e5e2da] bg-[#f1efe8] px-[18px] py-3 font-plex text-[13px] text-[#57534a]">
+              <button
+                type="button"
+                onClick={() =>
+                  navigator.clipboard
+                    .writeText("curl https://api.nba2kapi.com/api/players")
+                    .then(() => toast.success("curl command copied"))
+                }
+                title="Copy this command"
+                className="cursor-pointer rounded-full border border-[#e5e2da] bg-[#f1efe8] px-[18px] py-3 font-plex text-[13px] text-[#57534a] transition-[border-color,transform] duration-150 hover:border-[#1a1918] active:scale-[0.98] motion-reduce:transition-none"
+              >
                 $ curl api.nba2kapi.com/api/players
                 <span className="ml-1 inline-block h-3.5 w-[7px] translate-y-[2px] animate-[caret-blink_1.1s_step-end_infinite] bg-[#1a1918] motion-reduce:animate-none" />
-              </div>
+              </button>
             </div>
             <div
               className={cn("flex flex-wrap gap-x-8 gap-y-[18px] font-plex text-[12px] text-[#8a8577]", RISE_IN)}

--- a/app/players/[slug]/page.tsx
+++ b/app/players/[slug]/page.tsx
@@ -13,6 +13,7 @@ import { getRatingClasses, getRatingTier, getAttributeColor } from "@/lib/rating
 import { getTeamAbbreviation, formatTeamNickname } from "@/lib/team-abbr";
 import { ATTRIBUTE_CATEGORIES } from "@/convex/attributeCategories";
 import { getAttributeDisplayName } from "@/lib/attribute-normalizer";
+import { depthOrder } from "@/lib/depth-chart";
 import { API_KEY_STORAGE_KEY } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
@@ -101,6 +102,7 @@ function PlayerDossier() {
     typeParam === "curr" || typeParam === "class" || typeParam === "allt" ? typeParam : undefined;
 
   const [hasApiKey, setHasApiKey] = useState(false);
+  const [endpointCopied, setEndpointCopied] = useState(false);
   const dossier = useQuery(api.dossier.getDossier, {
     slug,
     teamType: requestedType,
@@ -114,19 +116,19 @@ function PlayerDossier() {
   const player = dossier?.player;
   const era = (player?.teamType ?? requestedType ?? "curr") as TeamType;
 
-  // Roster cycling
-  const rosterIndex = useMemo(() => {
-    if (!dossier) return -1;
-    return dossier.roster.findIndex((p) => p.slug === slug);
-  }, [dossier, slug]);
+  // Roster cycling follows the depth chart: starters PG→C, then bench by OVR
+  const cycleOrder = useMemo(
+    () => (dossier ? depthOrder(dossier.roster) : []),
+    [dossier]
+  );
+  const rosterIndex = useMemo(
+    () => cycleOrder.findIndex((p) => p.slug === slug),
+    [cycleOrder, slug]
+  );
   const prevPlayer =
-    dossier && rosterIndex >= 0
-      ? dossier.roster[(rosterIndex - 1 + dossier.roster.length) % dossier.roster.length]
-      : null;
+    rosterIndex >= 0 ? cycleOrder[(rosterIndex - 1 + cycleOrder.length) % cycleOrder.length] : null;
   const nextPlayer =
-    dossier && rosterIndex >= 0
-      ? dossier.roster[(rosterIndex + 1) % dossier.roster.length]
-      : null;
+    rosterIndex >= 0 ? cycleOrder[(rosterIndex + 1) % cycleOrder.length] : null;
 
   const teamQuery = player ? `&team=${encodeURIComponent(player.team)}` : "";
 
@@ -162,7 +164,7 @@ function PlayerDossier() {
     if (!dossier) return { pros: [], cons: [] };
     const entries = Object.entries(dossier.attrStats)
       .filter(([key]) => !SIGNATURE_EXCLUDE.has(key))
-      .sort((a, b) => b[1].pct - a[1].pct);
+      .sort((a, b) => b[1].pct - a[1].pct || b[1].value - a[1].value);
     const pos = dossier.primaryPosition ?? "position";
     const line = ([key, s]: (typeof entries)[number]) =>
       `${getAttributeDisplayName(key)} ${s.value} — ${ordinal(s.pct)} percentile among ${pos}s.`;
@@ -233,7 +235,7 @@ function PlayerDossier() {
 
   const badgeShelf = useMemo(() => {
     if (!dossier) return [];
-    const byTier = new Map<string, { name: string; slug: string }[]>();
+    const byTier = new Map<string, (typeof dossier.badges)[number][]>();
     for (const b of dossier.badges) {
       if (!byTier.has(b.tier)) byTier.set(b.tier, []);
       byTier.get(b.tier)!.push(b);
@@ -303,43 +305,37 @@ function PlayerDossier() {
           )}
           <div className="flex flex-wrap items-center gap-2">
             {prevPlayer && (
-              <Link href={`/players/${prevPlayer.slug}?type=${era}${teamQuery}`} className={cn(pillClass, "py-1.5 pr-3.5 pl-2.5")}>
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#8a8577" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="m15 18-6-6 6-6" />
-                </svg>
+              <Link href={`/players/${prevPlayer.slug}?type=${era}${teamQuery}`} className={cn(pillClass, "py-1.5 pr-3.5 pl-2")}>
+                <span className="flex h-[18px] w-[18px] items-center justify-center rounded-[4px] border border-[#d9d4c7] bg-[#faf9f5] font-plex text-[9px] leading-none text-[#57534a]">←</span>
                 <span className="font-plex text-[10px] tracking-[0.06em] text-[#57534a]">
                   {shortPlayerLabel(prevPlayer.name)} · {prevPlayer.overall}
                 </span>
               </Link>
             )}
             {nextPlayer && (
-              <Link href={`/players/${nextPlayer.slug}?type=${era}${teamQuery}`} className={cn(pillClass, "py-1.5 pr-2.5 pl-3.5")}>
+              <Link href={`/players/${nextPlayer.slug}?type=${era}${teamQuery}`} className={cn(pillClass, "py-1.5 pr-2 pl-3.5")}>
                 <span className="font-plex text-[10px] tracking-[0.06em] text-[#57534a]">
                   {shortPlayerLabel(nextPlayer.name)} · {nextPlayer.overall}
                 </span>
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#8a8577" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="m9 18 6-6-6-6" />
-                </svg>
+                <span className="flex h-[18px] w-[18px] items-center justify-center rounded-[4px] border border-[#d9d4c7] bg-[#faf9f5] font-plex text-[9px] leading-none text-[#57534a]">→</span>
               </Link>
             )}
-            <span className="font-plex text-[9px] tracking-[0.08em] text-[#b5b0a1]">
-              CYCLE THE ROSTER · ← →
-            </span>
           </div>
         </div>
 
         {/* Tier card + right column */}
         <div className="mt-[18px] grid grid-cols-[repeat(auto-fit,minmax(min(100%,320px),1fr))] items-stretch gap-[22px]">
           {/* MyTeam tier card */}
+          <div className="flex max-w-[420px] flex-col gap-2.5">
           <div
-            className={cn(
-              "relative min-h-[460px] max-w-[420px] overflow-hidden rounded-[22px] shadow-[0_30px_50px_-24px_rgba(26,25,24,0.45)] animate-[rise-in_400ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none",
-              player ? getRatingClasses(player.overall).bg : "bg-[#f1efe8]"
-            )}
+            className="relative min-h-[460px] flex-1 overflow-hidden rounded-[22px] bg-[#1a1918] shadow-[0_30px_50px_-24px_rgba(26,25,24,0.45)] animate-[rise-in_400ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
             style={{ animationDelay: "60ms" }}
           >
             {player && (
               <>
+                <div
+                  className={cn("absolute top-0 right-0 left-0 z-[3] h-1.5", getRatingClasses(player.overall).bg)}
+                />
                 <div className="absolute top-5 left-[22px] z-[2]">
                   <div className="font-plex text-[9.5px] tracking-[0.14em] text-white/85">
                     {tier.toUpperCase()} · {player.positions.join("/")} · {abbr}
@@ -369,6 +365,27 @@ function PlayerDossier() {
                 </div>
               </>
             )}
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              navigator.clipboard
+                .writeText(`https://api.nba2kapi.com/api/players/slug/${slug}`)
+                .then(() => {
+                  setEndpointCopied(true);
+                  setTimeout(() => setEndpointCopied(false), 1400);
+                });
+            }}
+            title="Copy the full request URL"
+            className="flex cursor-pointer items-center justify-between gap-2.5 rounded-full border border-[#e5e2da] bg-white px-4 py-2.5 font-plex text-[10px] text-[#57534a] transition-[border-color,transform] duration-150 hover:border-[#1a1918] active:scale-[0.98] motion-reduce:transition-none"
+          >
+            <span className="overflow-hidden text-ellipsis whitespace-nowrap">
+              GET /api/players/slug/{slug}
+            </span>
+            <span className="shrink-0 font-bold text-[#8a8577]">
+              {endpointCopied ? "COPIED ✓" : "COPY"}
+            </span>
+          </button>
           </div>
 
           {/* Right column */}
@@ -424,10 +441,10 @@ function PlayerDossier() {
               </div>
             </div>
 
-            {/* Endpoint + actions */}
+            {/* Actions */}
             <div className="flex flex-wrap items-center justify-between gap-2.5 rounded-[14px] border border-[#e5e2da] bg-white px-[18px] py-3">
-              <span className="font-plex text-[10px] text-[#57534a]">
-                GET /api/players/slug/{slug}
+              <span className="font-plex text-[9.5px] tracking-[0.12em] text-[#8a8577]">
+                TAKE HIM SOMEWHERE
               </span>
               <div className="flex gap-2">
                 <Link
@@ -681,9 +698,19 @@ function PlayerDossier() {
                     {row.chips.map((c) => (
                       <span
                         key={c.slug}
-                        className="rounded-full border border-[#e5e2da] bg-[#faf9f5] px-3 py-1 text-[12px] font-semibold text-[#1a1918]"
+                        className="group relative inline-flex items-center gap-1.5 rounded-full border border-[#e5e2da] bg-[#faf9f5] py-1 pr-3 pl-2 text-[12px] font-semibold text-[#1a1918]"
                       >
+                        {c.imageUrl && (
+                          <span className="relative h-4 w-4 shrink-0">
+                            <Image src={c.imageUrl} alt="" fill sizes="16px" className="object-contain" />
+                          </span>
+                        )}
                         {c.name}
+                        {c.description && (
+                          <span className="pointer-events-none absolute -top-[30px] left-0 z-10 hidden max-w-[280px] rounded-[6px] bg-[#1a1918] px-2.5 py-1.5 font-plex text-[8px] leading-[1.5] font-normal whitespace-normal text-[#faf9f5] shadow-[0_8px_16px_-8px_rgba(26,25,24,0.5)] group-hover:block">
+                            {c.description}
+                          </span>
+                        )}
                       </span>
                     ))}
                   </div>
@@ -716,9 +743,11 @@ function PlayerDossier() {
                     {rows.map(({ key, stat }) => (
                       <div
                         key={key}
-                        title={`${dossier!.primaryPosition ?? "League"} avg ${stat!.avg} · ${ordinal(stat!.pct)} percentile`}
-                        className="-mx-1 flex cursor-default items-center justify-between gap-1.5 rounded-[6px] px-1 py-px transition-colors duration-100 hover:bg-[#faf8f2]"
+                        className="group relative -mx-1 flex cursor-default items-center justify-between gap-1.5 rounded-[6px] px-1 py-px transition-colors duration-100 hover:bg-[#faf8f2]"
                       >
+                        <span className="pointer-events-none absolute -top-[26px] right-0 z-10 hidden rounded-[6px] bg-[#1a1918] px-2 py-1 font-plex text-[8px] whitespace-nowrap text-[#faf9f5] shadow-[0_8px_16px_-8px_rgba(26,25,24,0.5)] group-hover:block">
+                          {dossier!.primaryPosition ?? "LEAGUE"} AVG {stat!.avg} · {ordinal(stat!.pct).toUpperCase()} PCTL
+                        </span>
                         <span className="font-plex text-[9px] text-[#8a8577]">
                           {getAttributeDisplayName(key).toUpperCase()}
                         </span>

--- a/app/teams/[slug]/page.tsx
+++ b/app/teams/[slug]/page.tsx
@@ -299,10 +299,8 @@ function TeamPage() {
           </Link>
           <div className="flex flex-wrap items-center gap-2">
             {prevTeam && (
-              <Link href={`/teams/${prevTeam.slug}?type=${era}`} className={cn(pillClass, "py-1.5 pr-3.5 pl-2.5")}>
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#8a8577" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="m15 18-6-6 6-6" />
-                </svg>
+              <Link href={`/teams/${prevTeam.slug}?type=${era}`} className={cn(pillClass, "py-1.5 pr-3.5 pl-2")}>
+                <span className="flex h-[18px] w-[18px] items-center justify-center rounded-[4px] border border-[#d9d4c7] bg-[#faf9f5] font-plex text-[9px] leading-none text-[#57534a]">←</span>
                 <TeamLogo src={prevTeam.logo} team={prevTeam.team} size={20} />
                 <span className="font-plex text-[10px] tracking-[0.06em] text-[#57534a]">
                   <b className="text-[#1a1918]">
@@ -319,12 +317,9 @@ function TeamPage() {
                   {formatTeamNickname(nextTeam.team, era).toUpperCase()}
                 </span>
                 <TeamLogo src={nextTeam.logo} team={nextTeam.team} size={20} />
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="#8a8577" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="m9 18 6-6-6-6" />
-                </svg>
+                <span className="flex h-[18px] w-[18px] items-center justify-center rounded-[4px] border border-[#d9d4c7] bg-[#faf9f5] font-plex text-[9px] leading-none text-[#57534a]">→</span>
               </Link>
             )}
-            <span className="font-plex text-[9px] tracking-[0.08em] text-[#b5b0a1]">OR ← → KEYS</span>
           </div>
         </div>
 

--- a/components/chrome/command-palette.tsx
+++ b/components/chrome/command-palette.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import * as Dialog from "@radix-ui/react-dialog";
 import { Search } from "lucide-react";
@@ -25,7 +26,7 @@ type PoolPlayer = {
 
 type Result =
   | { kind: "player"; key: string; name: string; meta: string; href: string; player: PoolPlayer }
-  | { kind: "team"; key: string; name: string; meta: string; href: string; abbr: string }
+  | { kind: "team"; key: string; name: string; meta: string; href: string; abbr: string; logo: string | null }
   | { kind: "query"; key: string; name: string; meta: string; href: string };
 
 type Group = { label: string; items: Result[] };
@@ -40,6 +41,22 @@ function playerResult(p: PoolPlayer): Result {
     href: `/players/${p.slug}?type=${p.teamType}&team=${encodeURIComponent(p.team)}`,
     player: p,
   };
+}
+
+function TeamIcon({ logo, abbr, name }: { logo: string | null; abbr: string; name: string }) {
+  const [errored, setErrored] = useState(false);
+  if (!logo || errored) {
+    return (
+      <span className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-full bg-[#f1efe8] font-display text-[10px] font-extrabold text-[#57534a]">
+        {abbr}
+      </span>
+    );
+  }
+  return (
+    <span className="relative h-[30px] w-[30px] shrink-0">
+      <Image src={logo} alt={name} fill sizes="30px" className="object-contain" onError={() => setErrored(true)} />
+    </span>
+  );
 }
 
 export function CommandPalette({
@@ -68,6 +85,9 @@ export function CommandPalette({
     api.players.getPlaygroundPlayers,
     everOpened ? {} : "skip"
   ) as PoolPlayer[] | undefined;
+  const logoMap = useQuery(api.teams.getTeamLogoMap, everOpened ? {} : "skip") as
+    | Record<string, string>
+    | undefined;
 
   const teams = useMemo(() => {
     if (!players) return [];
@@ -101,9 +121,10 @@ export function CommandPalette({
         meta: `#${rank.get(`${t.team}:${t.teamType}`)}${conf ? ` · ${conf}` : ""} · ${t.avg.toFixed(1)} AVG${t.teamType === "curr" ? "" : t.teamType === "class" ? " · CLASSIC" : " · ALL-TIME"}`,
         href: `/teams/${t.team.toLowerCase().replace(/[^a-z0-9]+/g, "-")}?type=${t.teamType}`,
         abbr: getTeamAbbreviation(t.team),
+        logo: logoMap?.[t.team] ?? null,
       };
     });
-  }, [players]);
+  }, [players, logoMap]);
 
   const groups: Group[] = useMemo(() => {
     const query = q.trim().toLowerCase();
@@ -231,9 +252,7 @@ export function CommandPalette({
                       {item.kind === "player" ? (
                         <Headshot src={item.player.playerImage} name={item.name} size={30} />
                       ) : item.kind === "team" ? (
-                        <span className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-full bg-[#f1efe8] font-display text-[10px] font-extrabold text-[#57534a]">
-                          {item.abbr}
-                        </span>
+                        <TeamIcon logo={item.logo} abbr={item.abbr} name={item.name} />
                       ) : (
                         <span className="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-lg bg-[#1a1918]">
                           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#faf9f5" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">

--- a/convex/dossier.ts
+++ b/convex/dossier.ts
@@ -75,7 +75,12 @@ export const getDossier = query({
       .collect();
     const roster = rosterDocs
       .sort((a, b) => b.overall - a.overall)
-      .map((p) => ({ name: p.name, slug: p.slug, overall: p.overall }));
+      .map((p) => ({
+        name: p.name,
+        slug: p.slug,
+        overall: p.overall,
+        positions: p.positions ?? [],
+      }));
 
     // Cohort: same era, same primary position
     const primaryPosition = player.positions?.[0] ?? null;
@@ -174,9 +179,17 @@ export const getDossier = query({
     const badges = badgeLinks
       .map((l, i) => {
         const b = badgeDocs[i];
-        return b ? { name: b.name, slug: b.slug, tier: l.tier } : null;
+        return b
+          ? {
+              name: b.name,
+              slug: b.slug,
+              tier: l.tier,
+              imageUrl: b.imageUrl ?? null,
+              description: b.description ?? null,
+            }
+          : null;
       })
-      .filter((b): b is { name: string; slug: string; tier: string } => b !== null);
+      .filter((b): b is NonNullable<typeof b> => b !== null);
 
     return {
       player: {

--- a/convex/teams.ts
+++ b/convex/teams.ts
@@ -92,6 +92,21 @@ export const getBoard = query({
 });
 
 /**
+ * team name → logo URL map across all eras (command palette icons).
+ */
+export const getTeamLogoMap = query({
+  args: {},
+  handler: async (ctx) => {
+    const players = await ctx.db.query("players").collect();
+    const map: Record<string, string> = {};
+    for (const p of players) {
+      if (p.teamImg && !map[p.team]) map[p.team] = p.teamImg;
+    }
+    return map;
+  },
+});
+
+/**
  * Get detailed team statistics
  */
 export const getTeamStats = query({

--- a/lib/depth-chart.ts
+++ b/lib/depth-chart.ts
@@ -1,0 +1,56 @@
+/**
+ * Depth-chart assignment shared by the team page and dossier roster cycling.
+ * Starters stay positional (PG→C); everyone else is "the bench", flat by OVR
+ * (taste ruling 2026-07-10: the league is less position-bound than 2K's five
+ * slots, so only starters get sectioned).
+ */
+
+export const DEPTH_POSITIONS = ["PG", "SG", "SF", "PF", "C"] as const;
+
+type DepthPlayer = { overall: number; positions?: string[] };
+
+/** Primary-position columns with bench-steal for empty spots. */
+export function buildDepthColumns<T extends DepthPlayer>(roster: T[]): Record<string, T[]> {
+  const sorted = [...roster].sort((a, b) => b.overall - a.overall);
+  const columns: Record<string, T[]> = { PG: [], SG: [], SF: [], PF: [], C: [] };
+  for (const p of sorted) {
+    const primary = p.positions?.find((pos) => pos in columns);
+    columns[primary ?? "SF"].push(p);
+  }
+  for (const pos of DEPTH_POSITIONS) {
+    if (columns[pos].length > 0) continue;
+    let candidate: { from: string; index: number } | null = null;
+    for (const from of DEPTH_POSITIONS) {
+      columns[from].forEach((p, index) => {
+        if (index === 0) return; // never steal a starter
+        if (!p.positions?.includes(pos)) return;
+        if (!candidate || p.overall > columns[candidate.from][candidate.index].overall) {
+          candidate = { from, index };
+        }
+      });
+    }
+    if (candidate !== null) {
+      const c: { from: string; index: number } = candidate;
+      columns[pos].push(columns[c.from].splice(c.index, 1)[0]);
+    }
+  }
+  return columns;
+}
+
+/** Five starters (PG→C order; missing spots omitted). */
+export function depthStarters<T extends DepthPlayer>(columns: Record<string, T[]>): T[] {
+  return DEPTH_POSITIONS.map((pos) => columns[pos][0]).filter((p): p is T => p !== undefined);
+}
+
+/** Flat bench, highest OVR first. */
+export function depthBench<T extends DepthPlayer>(columns: Record<string, T[]>): T[] {
+  return DEPTH_POSITIONS.flatMap((pos) => columns[pos].slice(1)).sort(
+    (a, b) => b.overall - a.overall
+  );
+}
+
+/** Depth-chart traversal order: starters PG→C, then the bench by OVR. */
+export function depthOrder<T extends DepthPlayer>(roster: T[]): T[] {
+  const columns = buildDepthColumns(roster);
+  return [...depthStarters(columns), ...depthBench(columns)];
+}


### PR DESCRIPTION
First of four PRs from Wilson's review pass. Quick wins:

- **Dossier tier card**: full-bleed tier gradient replaced with a neutral dark card + tier-gradient accent strip; photos no longer clash with the background.
- **Endpoint chip**: now a copy button (full request URL, COPIED feedback) sitting under the card; Compare / Whiteboard actions live in their own row.
- **Cycling**: "CYCLE THE ROSTER" / "OR ← → KEYS" help text removed; pills show keyboard-key-styled arrows; dossier cycling follows depth-chart order (starters PG→C, then bench by OVR) via shared `lib/depth-chart.ts`.
- **Matrix hover**: visible dark tooltip with position average + percentile (the `title` attribute was too subtle to discover). Badge chips now render badge images and hover descriptions wherever named badges exist (prod; dev's junction table is empty).
- **Palette team logos**: new `getTeamLogoMap` query; monogram fallback stays for broken URLs.
- **Landing curl pill**: click-to-copy with toast.

Verified in browser: new card on Jokic, kbd pills, 6/6 palette team rows with logos, tooltip visible, copy affordances working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)