### PR TITLE
feat: playground v2 — dropdown slots, any-attribute queries, pagination, visible response

### DIFF
--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -240,11 +240,23 @@ function Playground() {
     setHasApiKey(!!localStorage.getItem(API_KEY_STORAGE_KEY));
   }, []);
 
-  // URL mirror
+  // Two-way URL sync. lastSyncedRef remembers the last string either side
+  // agreed on, so an externally-changed URL (back/forward, in-app link) is
+  // adopted into state instead of being clobbered by a stale mirror write.
+  const lastSyncedRef = useRef(searchParams.toString());
   useEffect(() => {
-    const qs = paramsFromState(q);
-    if (qs !== searchParams.toString()) {
-      router.replace(`/playground?${qs}`, { scroll: false });
+    const urlNow = searchParams.toString();
+    const stateNow = paramsFromState(q);
+    if (urlNow === stateNow) {
+      lastSyncedRef.current = urlNow;
+      return;
+    }
+    if (urlNow !== lastSyncedRef.current) {
+      lastSyncedRef.current = urlNow;
+      setQ(stateFromParams(new URLSearchParams(urlNow)));
+    } else {
+      lastSyncedRef.current = stateNow;
+      router.replace(`/playground?${stateNow}`, { scroll: false });
     }
   }, [q, router, searchParams]);
 
@@ -270,11 +282,17 @@ function Playground() {
     | { players: TablePlayer[]; totalCount: number; hasMore: boolean }
     | undefined;
 
-  // Keep the previous page rendered while the next loads (no flash)
-  const lastResult = useRef(result);
-  if (result) lastResult.current = result;
-  const data = result ?? lastResult.current;
-  const updating = result === undefined && lastResult.current !== undefined;
+  // Keep the previous page rendered while the next loads (no flash). The
+  // page number is cached WITH the result so stale rows keep their own
+  // ranks/footer instead of borrowing the incoming page's.
+  const lastGood = useRef<{ data: NonNullable<typeof result>; page: number } | undefined>(
+    undefined
+  );
+  if (result) lastGood.current = { data: result, page: q.page };
+  const shown = result ? { data: result, page: q.page } : lastGood.current;
+  const data = shown?.data;
+  const shownPage = shown?.page ?? 0;
+  const updating = result === undefined && lastGood.current !== undefined;
 
   const requestUrl = `/api/players?${paramsFromState(q)}`;
   const totalPages = data ? Math.max(1, Math.ceil(data.totalCount / PAGE_SIZE)) : 1;
@@ -648,7 +666,7 @@ function Playground() {
         >
           <PlayerTable
             players={data?.players ?? []}
-            rankOffset={q.page * PAGE_SIZE}
+            rankOffset={shownPage * PAGE_SIZE}
             queriedKey={q.filter?.key ?? null}
             sortKey={q.sortKey}
             sortDir={q.sortDir}
@@ -675,7 +693,7 @@ function Playground() {
               </button>
               <span className="font-plex text-[8.5px] text-[#8a8577]">
                 {data
-                  ? `SHOWING ${data.totalCount === 0 ? 0 : q.page * PAGE_SIZE + 1}–${Math.min((q.page + 1) * PAGE_SIZE, data.totalCount)} OF ${data.totalCount} · PAGE ${Math.min(q.page + 1, totalPages)}/${totalPages}`
+                  ? `SHOWING ${data.totalCount === 0 ? 0 : shownPage * PAGE_SIZE + 1}–${Math.min((shownPage + 1) * PAGE_SIZE, data.totalCount)} OF ${data.totalCount} · PAGE ${Math.min(shownPage + 1, totalPages)}/${totalPages}`
                   : "…"}
               </span>
               <button

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -1,235 +1,246 @@
 "use client";
 
-import { Suspense, useEffect, useMemo, useState } from "react";
-import Link from "next/link";
+import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useQuery } from "convex/react";
+import { useConvex, useQuery } from "convex/react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { toast } from "sonner";
 import { api } from "@/convex/_generated/api";
 import { TopNav } from "@/components/chrome/top-nav";
 import { FooterStrip } from "@/components/chrome/footer-strip";
-import { Headshot } from "@/components/ui/headshot";
-import { getRatingClasses, getAttributeColor } from "@/lib/rating-colors";
-import { getTeamAbbreviation } from "@/lib/team-abbr";
+import { PlayerTable, type TablePlayer } from "@/components/ui/player-table";
+import { ATTRIBUTE_PARAM_ALIASES } from "@/convex/_validation";
+import { ATTRIBUTE_CATEGORIES } from "@/convex/attributeCategories";
+import { ATTRIBUTE_SHORT_LABELS } from "@/lib/attribute-labels";
+import { getAttributeDisplayName } from "@/lib/attribute-normalizer";
 import { API_KEY_STORAGE_KEY } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
-// ---- Sentence slots -------------------------------------------------------
+// ---- vocabulary -------------------------------------------------------------
 
-const POS_SLOTS = [
-  { label: "guards", param: "guard", positions: ["PG", "SG"] as string[] | null },
-  { label: "wings", param: "wing", positions: ["SG", "SF"] as string[] | null },
-  { label: "bigs", param: "big", positions: ["PF", "C"] as string[] | null },
-  { label: "anyone", param: "any", positions: null },
+const POS_OPTIONS = [
+  { value: "any", label: "anyone" },
+  { value: "guard", label: "guards" },
+  { value: "wing", label: "wings" },
+  { value: "big", label: "bigs" },
+  { value: "PG", label: "PGs" },
+  { value: "SG", label: "SGs" },
+  { value: "SF", label: "SFs" },
+  { value: "PF", label: "PFs" },
+  { value: "C", label: "Cs" },
 ];
-
-const ERA_SLOTS = [
-  { label: "any era", param: "all" },
-  { label: "the current league", param: "curr" },
-  { label: "the classics", param: "class" },
-];
-
-const THREE_SLOTS = [
-  { label: "3PT ≥ 80", v: 80 },
-  { label: "3PT ≥ 85", v: 85 },
-  { label: "3PT ≥ 90", v: 90 },
-  { label: "any 3PT", v: 0 },
-];
-
-type SortKey = "overall" | "tpt" | "spd" | "dnk" | "def";
-const SORT_KEYS: SortKey[] = ["overall", "tpt", "spd", "dnk", "def"];
-const SORT_LABELS: Record<SortKey, string> = {
-  overall: "overall",
-  tpt: "three ball",
-  spd: "speed",
-  dnk: "dunking",
-  def: "defense",
-};
-const SORT_URL_NAMES: Record<SortKey, string> = {
-  overall: "overall",
-  tpt: "three_ball",
-  spd: "speed",
-  dnk: "driving_dunk",
-  def: "perimeter_defense",
+const POS_GROUPS: Record<string, string[]> = {
+  guard: ["PG", "SG"],
+  wing: ["SG", "SF"],
+  big: ["PF", "C"],
 };
 
-type PlaygroundPlayer = {
-  name: string;
-  slug: string;
-  team: string;
-  teamType: "curr" | "class" | "allt";
-  positions: string[];
-  overall: number;
-  playerImage: string | null;
-  threePointShot: number | null;
-  speed: number | null;
-  drivingDunk: number | null;
-  perimeterDefense: number | null;
+const ERA_OPTIONS = [
+  { value: "all", label: "any era" },
+  { value: "curr", label: "the current league" },
+  { value: "class", label: "the classics" },
+  { value: "allt", label: "the all-time teams" },
+] as const;
+type Era = (typeof ERA_OPTIONS)[number]["value"];
+
+const THRESHOLDS = [60, 70, 75, 80, 85, 90, 95];
+
+// camelCase attribute → snake alias for URLs (friendly aliases win)
+const CAMEL_TO_SNAKE: Record<string, string> = {};
+for (const [snake, camel] of Object.entries(ATTRIBUTE_PARAM_ALIASES)) {
+  CAMEL_TO_SNAKE[camel] = snake;
+}
+
+const PAGE_SIZE = 50;
+
+type Filter = { key: string; gte: number } | null;
+
+type QueryState = {
+  pos: string;
+  era: Era;
+  filter: Filter;
+  sortKey: string; // "overall" | attribute key
+  sortDir: "asc" | "desc";
+  team: string | null;
+  search: string | null;
+  page: number;
 };
 
-const ATTR_OF: Record<Exclude<SortKey, "overall">, (p: PlaygroundPlayer) => number | null> = {
-  tpt: (p) => p.threePointShot,
-  spd: (p) => p.speed,
-  dnk: (p) => p.drivingDunk,
-  def: (p) => p.perimeterDefense,
+const SHOWCASE: QueryState = {
+  pos: "guard",
+  era: "all",
+  filter: { key: "threePointShot", gte: 85 },
+  sortKey: "overall",
+  sortDir: "desc",
+  team: null,
+  search: null,
+  page: 0,
 };
 
-const SAVED_QUERIES = [
-  { label: "Lockdown wings, any era", pos: 1, era: 0, three: 3, sortKey: "def" as SortKey, team: null },
-  { label: "7-footers who shoot 80+", pos: 2, era: 0, three: 0, sortKey: "tpt" as SortKey, team: null },
-  { label: "'96 Bulls full roster", pos: 3, era: 2, three: 3, sortKey: "overall" as SortKey, team: "1995-96 Chicago Bulls" },
+const SAVED_QUERIES: { label: string; state: QueryState }[] = [
+  {
+    label: "Lockdown wings, any era",
+    state: { pos: "wing", era: "all", filter: { key: "perimeterDefense", gte: 85 }, sortKey: "perimeterDefense", sortDir: "desc", team: null, search: null, page: 0 },
+  },
+  {
+    label: "Bigs who shoot 80+",
+    state: { pos: "big", era: "all", filter: { key: "threePointShot", gte: 80 }, sortKey: "threePointShot", sortDir: "desc", team: null, search: null, page: 0 },
+  },
+  {
+    label: "'96 Bulls full roster",
+    state: { pos: "any", era: "class", filter: null, sortKey: "overall", sortDir: "desc", team: "1995-96 Chicago Bulls", search: null, page: 0 },
+  },
 ];
-
-const ROW_LIMIT = 50;
-
-// ---- Helpers ---------------------------------------------------------------
-
-function sortValue(p: PlaygroundPlayer, key: SortKey): number | null {
-  return key === "overall" ? p.overall : ATTR_OF[key](p);
-}
-
-function shortTeam(p: PlaygroundPlayer): string {
-  const abbr = getTeamAbbreviation(p.team);
-  if (p.teamType === "class") {
-    const match = p.team.match(/^\d{4}-(\d{2})\s/);
-    return match ? `${abbr} '${match[1]}` : abbr;
-  }
-  if (p.teamType === "allt") return `${abbr} A-T`;
-  return abbr;
-}
-
-function eraTag(teamType: PlaygroundPlayer["teamType"]) {
-  if (teamType === "class") return { label: "CLASSIC", color: "#9a6700" };
-  if (teamType === "allt") return { label: "ALL-TIME", color: "#9a6700" };
-  return { label: "CURRENT", color: "#8a8577" };
-}
-
-function OvrChip({ ovr }: { ovr: number }) {
-  return (
-    <span
-      className={cn(
-        "inline-flex w-[38px] items-center justify-center rounded-[6px] py-[3px] text-[12px] font-bold text-white tabular-nums",
-        getRatingClasses(ovr).bg
-      )}
-    >
-      {ovr}
-    </span>
-  );
-}
-
-function AttrCell({ value, highlighted = false }: { value: number | null; highlighted?: boolean }) {
-  return (
-    <span
-      className={cn(
-        "text-center text-[12.5px] font-bold tabular-nums",
-        highlighted && "rounded-[5px] bg-[#faf7ee] py-[3px]"
-      )}
-      style={{ color: value === null ? "#b5b0a1" : getAttributeColor(value) }}
-    >
-      {value ?? "—"}
-    </span>
-  );
-}
-
-function SlotChevron() {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="#b5b0a1"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="m6 9 6 6 6-6" />
-    </svg>
-  );
-}
-
-function Slot({ label, onClick }: { label: string; onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="inline-flex cursor-pointer items-center gap-1.5 border-b-2 border-dashed border-[#d9d4c7] px-[3px] pb-px font-extrabold text-[#1a1918] transition-[border-color] duration-150 select-none hover:border-[#1a1918] active:scale-[0.98]"
-    >
-      {label}
-      <SlotChevron />
-    </button>
-  );
-}
 
 // ---- URL <-> state ----------------------------------------------------------
 
-type QueryState = {
-  pos: number;
-  era: number;
-  three: number;
-  sortKey: SortKey;
-  sortDir: -1 | 1;
-  team: string | null;
-  search: string | null;
-};
-
 function stateFromParams(sp: URLSearchParams): QueryState {
-  // Pristine /playground gets the design's showcase defaults. A URL that
-  // carries any query param is a deep link — unspecified slots must stay
-  // wide open ("anyone" / "any era" / "any 3PT") so the link isn't narrowed.
-  const isDeepLink = ["position", "era", "three_ball_gte", "sort", "team", "search"].some((k) => sp.has(k));
-  if (!isDeepLink) {
-    return { pos: 0, era: 0, three: 1, sortKey: "overall", sortDir: -1, team: null, search: null };
+  const known = ["position", "era", "sort", "team", "search", "cursor"];
+  const hasGte = [...sp.keys()].some(
+    (k) => k.endsWith("_gte") && ATTRIBUTE_PARAM_ALIASES[k.slice(0, -4)]
+  );
+  const isDeepLink = known.some((k) => sp.has(k)) || hasGte;
+  if (!isDeepLink) return SHOWCASE;
+
+  const posRaw = sp.get("position");
+  const pos =
+    posRaw && POS_OPTIONS.some((o) => o.value === posRaw)
+      ? posRaw
+      : posRaw && POS_OPTIONS.some((o) => o.value === posRaw.toUpperCase())
+        ? posRaw.toUpperCase()
+        : "any";
+
+  const eraRaw = sp.get("era");
+  const era: Era = ERA_OPTIONS.some((o) => o.value === eraRaw) ? (eraRaw as Era) : "all";
+
+  let filter: Filter = null;
+  for (const [key, value] of sp.entries()) {
+    if (!key.endsWith("_gte")) continue;
+    const attr = ATTRIBUTE_PARAM_ALIASES[key.slice(0, -4)];
+    const num = Number(value);
+    if (attr && Number.isFinite(num)) {
+      filter = { key: attr, gte: num };
+      break;
+    }
   }
-  const posIdx = POS_SLOTS.findIndex((s) => s.param === sp.get("position"));
-  const eraIdx = ERA_SLOTS.findIndex((s) => s.param === sp.get("era"));
-  const threeIdx = sp.has("three_ball_gte")
-    ? THREE_SLOTS.findIndex((s) => s.v === Number(sp.get("three_ball_gte")))
-    : -1;
-  const [sortField, sortDir] = (sp.get("sort") ?? "").split(":");
+
+  const [sortField, sortDirRaw] = (sp.get("sort") ?? "").split(":");
   const sortKey =
-    (Object.entries(SORT_URL_NAMES).find(([, url]) => url === sortField)?.[0] as SortKey) ??
-    "overall";
+    sortField === "overall" ? "overall" : (ATTRIBUTE_PARAM_ALIASES[sortField] ?? "overall");
+
+  const cursor = Number(sp.get("cursor"));
   return {
-    pos: posIdx >= 0 ? posIdx : 3,
-    era: eraIdx >= 0 ? eraIdx : 0,
-    three: threeIdx >= 0 ? threeIdx : 3,
+    pos,
+    era,
+    filter,
     sortKey,
-    sortDir: sortDir === "asc" ? 1 : -1,
+    sortDir: sortDirRaw === "asc" ? "asc" : "desc",
     team: sp.get("team"),
     search: sp.get("search"),
+    page: Number.isFinite(cursor) && cursor > 0 ? Math.floor(cursor / PAGE_SIZE) : 0,
   };
 }
 
 function paramsFromState(s: QueryState): string {
   const params = new URLSearchParams();
-  const pos = POS_SLOTS[s.pos];
-  if (pos.param !== "any") params.set("position", pos.param);
-  params.set("era", ERA_SLOTS[s.era].param);
-  if (THREE_SLOTS[s.three].v > 0) params.set("three_ball_gte", String(THREE_SLOTS[s.three].v));
+  if (s.pos !== "any") params.set("position", s.pos);
+  params.set("era", s.era);
+  if (s.filter)
+    params.set(`${CAMEL_TO_SNAKE[s.filter.key] ?? s.filter.key}_gte`, String(s.filter.gte));
   if (s.team) params.set("team", s.team);
   if (s.search) params.set("search", s.search);
-  params.set("sort", `${SORT_URL_NAMES[s.sortKey]}:${s.sortDir === -1 ? "desc" : "asc"}`);
+  params.set(
+    "sort",
+    `${s.sortKey === "overall" ? "overall" : (CAMEL_TO_SNAKE[s.sortKey] ?? s.sortKey)}:${s.sortDir}`
+  );
+  if (s.page > 0) params.set("cursor", String(s.page * PAGE_SIZE));
   return params.toString();
 }
 
-// ---- Page -----------------------------------------------------------------
+// ---- slot menus ---------------------------------------------------------------
+
+const MENU_CONTENT =
+  "z-50 max-h-[340px] min-w-[210px] overflow-y-auto rounded-xl border border-[#e5e2da] bg-white p-1 font-body shadow-[0_24px_48px_-20px_rgba(26,25,24,0.35)]";
+const MENU_ITEM =
+  "flex cursor-pointer items-center justify-between gap-3 rounded-lg px-3 py-1.5 text-[12.5px] font-semibold text-[#1a1918] outline-none select-none data-[highlighted]:bg-[#f1efe8]";
+const MENU_LABEL = "px-3 pt-2 pb-1 font-plex text-[7.5px] tracking-[0.12em] text-[#b5b0a1]";
+
+function SlotTrigger({ children }: { children: React.ReactNode }) {
+  return (
+    <DropdownMenu.Trigger asChild>
+      <button
+        type="button"
+        className="inline-flex cursor-pointer items-center gap-1.5 border-b-2 border-dashed border-[#d9d4c7] px-[3px] pb-px font-extrabold text-[#1a1918] transition-[border-color] duration-150 outline-none select-none hover:border-[#1a1918] data-[state=open]:border-[#1a1918]"
+      >
+        {children}
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#b5b0a1" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="m6 9 6 6 6-6" />
+        </svg>
+      </button>
+    </DropdownMenu.Trigger>
+  );
+}
+
+function Check({ on }: { on: boolean }) {
+  return on ? <span className="text-[10px] text-[#0a7f3f]">●</span> : null;
+}
+
+function AttributeMenuItems({
+  current,
+  onPick,
+}: {
+  current: string | null;
+  onPick: (key: string) => void;
+}) {
+  return (
+    <>
+      {(Object.entries(ATTRIBUTE_CATEGORIES) as [string, readonly string[]][]).map(
+        ([category, keys]) => (
+          <div key={category}>
+            <div className={MENU_LABEL}>{category.replace(/([A-Z])/g, " $1").toUpperCase()}</div>
+            {keys.map((key) => (
+              <DropdownMenu.Item key={key} className={MENU_ITEM} onSelect={() => onPick(key)}>
+                <span>
+                  {getAttributeDisplayName(key)}{" "}
+                  <span className="font-plex text-[8px] text-[#b5b0a1]">
+                    {ATTRIBUTE_SHORT_LABELS[key]}
+                  </span>
+                </span>
+                <Check on={current === key} />
+              </DropdownMenu.Item>
+            ))}
+          </div>
+        )
+      )}
+    </>
+  );
+}
+
+// ---- page -------------------------------------------------------------------
+
+function filterLabel(filter: Filter): string {
+  if (!filter) return "no attribute floor";
+  return `${ATTRIBUTE_SHORT_LABELS[filter.key] ?? filter.key} ≥ ${filter.gte}`;
+}
+
+function sortLabel(sortKey: string): string {
+  return sortKey === "overall" ? "overall" : getAttributeDisplayName(sortKey).toLowerCase();
+}
 
 function Playground() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const convex = useConvex();
   const [q, setQ] = useState<QueryState>(() => stateFromParams(searchParams));
   const [copied, setCopied] = useState(false);
   const [hasApiKey, setHasApiKey] = useState(false);
-
-  const players = useQuery(api.players.getPlaygroundPlayers) as PlaygroundPlayer[] | undefined;
+  const [responseOpen, setResponseOpen] = useState(false);
 
   useEffect(() => {
     setHasApiKey(!!localStorage.getItem(API_KEY_STORAGE_KEY));
   }, []);
 
-  // Keep the URL shareable: mirror the sentence into query params.
+  // URL mirror
   useEffect(() => {
     const qs = paramsFromState(q);
     if (qs !== searchParams.toString()) {
@@ -237,56 +248,47 @@ function Playground() {
     }
   }, [q, router, searchParams]);
 
+  const queryArgs = useMemo(
+    () => ({
+      teamType: q.era === "all" ? undefined : q.era,
+      positions: POS_GROUPS[q.pos] ?? (q.pos !== "any" ? [q.pos] : undefined),
+      attributeFilters: q.filter ? [{ key: q.filter.key, gte: q.filter.gte }] : undefined,
+      sortBy:
+        q.sortKey === "overall"
+          ? (`overall-${q.sortDir}` as "overall-asc" | "overall-desc")
+          : undefined,
+      sortByAttribute: q.sortKey !== "overall" ? { key: q.sortKey, dir: q.sortDir } : undefined,
+      search: q.search ?? undefined,
+      teams: q.team ? [q.team] : undefined,
+      limit: PAGE_SIZE,
+      offset: q.page * PAGE_SIZE,
+    }),
+    [q]
+  );
+
+  const result = useQuery(api.players.getAllFiltered, queryArgs) as
+    | { players: TablePlayer[]; totalCount: number; hasMore: boolean }
+    | undefined;
+
+  // Keep the previous page rendered while the next loads (no flash)
+  const lastResult = useRef(result);
+  if (result) lastResult.current = result;
+  const data = result ?? lastResult.current;
+  const updating = result === undefined && lastResult.current !== undefined;
+
   const requestUrl = `/api/players?${paramsFromState(q)}`;
+  const totalPages = data ? Math.max(1, Math.ceil(data.totalCount / PAGE_SIZE)) : 1;
 
-  const filtered = useMemo(() => {
-    if (!players) return [];
-    const pos = POS_SLOTS[q.pos];
-    const era = ERA_SLOTS[q.era].param;
-    const minThree = THREE_SLOTS[q.three].v;
-    const sign = q.sortDir;
-    return players
-      .filter((p) => {
-        if (pos.positions && !p.positions.some((x) => pos.positions!.includes(x))) return false;
-        if (era !== "all" && p.teamType !== era) return false;
-        if (minThree > 0 && (p.threePointShot === null || p.threePointShot < minThree)) return false;
-        if (q.team && p.team !== q.team) return false;
-        if (q.search && !p.name.toLowerCase().includes(q.search.toLowerCase())) return false;
-        return true;
-      })
-      .sort((a, b) => {
-        const av = sortValue(a, q.sortKey);
-        const bv = sortValue(b, q.sortKey);
-        if (av === null && bv === null) return b.overall - a.overall;
-        if (av === null) return 1;
-        if (bv === null) return -1;
-        const d = sign === -1 ? bv - av : av - bv;
-        return d !== 0 ? d : b.overall - a.overall;
-      });
-  }, [players, q]);
+  const set = (patch: Partial<QueryState>) =>
+    setQ((s) => ({ ...s, ...patch, page: patch.page ?? 0 }));
 
-  const rows = filtered.slice(0, ROW_LIMIT);
-  const first = filtered[0];
-
-  const cycle = (key: "pos" | "era" | "three", len: number) => () =>
-    setQ((s) => ({ ...s, [key]: (s[key] + 1) % len, team: null }));
-
-  const cycleSort = () =>
-    setQ((s) => ({
-      ...s,
-      sortKey: SORT_KEYS[(SORT_KEYS.indexOf(s.sortKey) + 1) % SORT_KEYS.length],
-      sortDir: -1,
-    }));
-
-  const sortBy = (key: SortKey) => () =>
+  const onSort = (key: string) =>
     setQ((s) => ({
       ...s,
       sortKey: key,
-      sortDir: s.sortKey === key ? ((-s.sortDir) as -1 | 1) : -1,
+      sortDir: s.sortKey === key ? (s.sortDir === "desc" ? "asc" : "desc") : "desc",
+      page: 0,
     }));
-
-  const arrow = (key: SortKey) => (q.sortKey === key ? (q.sortDir === -1 ? " ↓" : " ↑") : "");
-  const headColor = (key: SortKey) => (q.sortKey === key ? "#1a1918" : "#b5b0a1");
 
   const copyUrl = () => {
     navigator.clipboard.writeText(`https://api.nba2kapi.com${requestUrl}`).then(() => {
@@ -295,19 +297,38 @@ function Playground() {
     });
   };
 
-  const exportCsv = () => {
-    const header = "name,slug,team,era,overall,three_ball,speed,driving_dunk,perimeter_defense";
-    const lines = filtered.map((p) =>
+  const fetchAll = async () => {
+    const full = await convex.query(api.players.getAllFiltered, {
+      ...queryArgs,
+      limit: 2000,
+      offset: 0,
+    });
+    return full.players as TablePlayer[];
+  };
+
+  const exportCsv = async () => {
+    const players = await fetchAll();
+    const attrKeys = Object.values(ATTRIBUTE_CATEGORIES).flat();
+    const header = [
+      "name",
+      "slug",
+      "team",
+      "era",
+      "positions",
+      "height",
+      "overall",
+      ...attrKeys.map((k) => CAMEL_TO_SNAKE[k] ?? k),
+    ].join(",");
+    const lines = players.map((p) =>
       [
         `"${p.name.replace(/"/g, '""')}"`,
         p.slug,
         `"${p.team.replace(/"/g, '""')}"`,
         p.teamType,
+        `"${(p.positions ?? []).join("/")}"`,
+        p.height ?? "",
         p.overall,
-        p.threePointShot ?? "",
-        p.speed ?? "",
-        p.drivingDunk ?? "",
-        p.perimeterDefense ?? "",
+        ...attrKeys.map((k) => p.attributes?.[k] ?? ""),
       ].join(",")
     );
     const blob = new Blob([[header, ...lines].join("\n")], { type: "text/csv" });
@@ -317,36 +338,29 @@ function Playground() {
     a.download = "nba2kapi-query.csv";
     a.click();
     URL.revokeObjectURL(url);
-    toast.success(`Exported ${filtered.length} players`);
+    toast.success(`Exported ${players.length} players — every attribute included`);
   };
 
-  const copyJson = () => {
+  const copyJson = async () => {
+    const players = await fetchAll();
     const payload = {
       success: true,
-      count: filtered.length,
-      results: filtered.map((p) => ({
+      count: players.length,
+      results: players.map((p) => ({
         name: p.name,
         slug: p.slug,
         team: p.team,
         era: p.teamType,
+        positions: p.positions ?? [],
         overall: p.overall,
-        three_ball: p.threePointShot,
-        speed: p.speed,
-        driving_dunk: p.drivingDunk,
-        perimeter_defense: p.perimeterDefense,
+        attributes: p.attributes ?? {},
       })),
     };
-    navigator.clipboard
-      .writeText(JSON.stringify(payload, null, 2))
-      .then(() => toast.success("Response JSON copied"));
+    await navigator.clipboard.writeText(JSON.stringify(payload, null, 2));
+    toast.success(`Response JSON copied (${players.length} players)`);
   };
 
-  const applySaved = (s: (typeof SAVED_QUERIES)[number]) =>
-    setQ({ pos: s.pos, era: s.era, three: s.three, sortKey: s.sortKey, sortDir: -1, team: s.team, search: null });
-
-  const monoHead = "font-plex text-[8.5px] tracking-[0.08em]";
-  const rowGrid =
-    "grid grid-cols-[34px_30px_minmax(150px,1fr)_80px_54px_54px_repeat(3,46px)] items-center gap-2.5 px-4";
+  const first = data?.players[0];
 
   return (
     <div className="min-h-screen bg-[#faf9f5] font-body text-[#1a1918]">
@@ -357,17 +371,127 @@ function Playground() {
         <div className="rounded-2xl border border-[#e5e2da] bg-white p-[clamp(16px,2.5vw,24px)]">
           <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
             <span className="font-plex text-[9.5px] tracking-[0.12em] text-[#8a8577]">
-              QUERY — CLICK ANY SLOT TO CHANGE IT
+              QUERY — OPEN ANY SLOT TO CHANGE IT
             </span>
-            <span className="font-plex text-[9px] text-[#b5b0a1]">SAVED QUERIES →</span>
+            <span className="font-plex text-[9px] text-[#b5b0a1]">
+              EVERY SLOT MAPS TO AN API PARAMETER
+            </span>
           </div>
-          <div className="font-display text-[clamp(19px,2.2vw,25px)] leading-[1.7] font-semibold tracking-[-0.02em] text-[#57534a]">
-            Show me <Slot label={POS_SLOTS[q.pos].label} onClick={cycle("pos", POS_SLOTS.length)} />{" "}
-            from <Slot label={ERA_SLOTS[q.era].label} onClick={cycle("era", ERA_SLOTS.length)} />{" "}
+
+          <div className="font-display text-[clamp(19px,2.2vw,25px)] leading-[1.75] font-semibold tracking-[-0.02em] text-[#57534a]">
+            Show me{" "}
+            <DropdownMenu.Root>
+              <SlotTrigger>{POS_OPTIONS.find((o) => o.value === q.pos)?.label}</SlotTrigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content className={MENU_CONTENT} sideOffset={6} align="start">
+                  <div className={MENU_LABEL}>GROUPS</div>
+                  {POS_OPTIONS.slice(0, 4).map((o) => (
+                    <DropdownMenu.Item
+                      key={o.value}
+                      className={MENU_ITEM}
+                      onSelect={() => set({ pos: o.value })}
+                    >
+                      {o.label} <Check on={q.pos === o.value} />
+                    </DropdownMenu.Item>
+                  ))}
+                  <div className={MENU_LABEL}>EXACT POSITION</div>
+                  {POS_OPTIONS.slice(4).map((o) => (
+                    <DropdownMenu.Item
+                      key={o.value}
+                      className={MENU_ITEM}
+                      onSelect={() => set({ pos: o.value })}
+                    >
+                      {o.label} <Check on={q.pos === o.value} />
+                    </DropdownMenu.Item>
+                  ))}
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>{" "}
+            from{" "}
+            <DropdownMenu.Root>
+              <SlotTrigger>{ERA_OPTIONS.find((o) => o.value === q.era)?.label}</SlotTrigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content className={MENU_CONTENT} sideOffset={6} align="start">
+                  {ERA_OPTIONS.map((o) => (
+                    <DropdownMenu.Item
+                      key={o.value}
+                      className={MENU_ITEM}
+                      onSelect={() => set({ era: o.value })}
+                    >
+                      {o.label} <Check on={q.era === o.value} />
+                    </DropdownMenu.Item>
+                  ))}
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>{" "}
             with{" "}
-            <Slot label={THREE_SLOTS[q.three].label} onClick={cycle("three", THREE_SLOTS.length)} />
-            , ranked by <Slot label={SORT_LABELS[q.sortKey]} onClick={cycleSort} />
+            <DropdownMenu.Root>
+              <SlotTrigger>{filterLabel(q.filter)}</SlotTrigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  className={cn(MENU_CONTENT, "min-w-[260px]")}
+                  sideOffset={6}
+                  align="start"
+                >
+                  <div className={MENU_LABEL}>FLOOR</div>
+                  <div className="flex flex-wrap gap-1 px-2 pb-1.5">
+                    {THRESHOLDS.map((t) => (
+                      <button
+                        key={t}
+                        type="button"
+                        onClick={() =>
+                          set({ filter: { key: q.filter?.key ?? "threePointShot", gte: t } })
+                        }
+                        className={cn(
+                          "cursor-pointer rounded-full border px-2.5 py-0.5 font-plex text-[9px] font-bold",
+                          q.filter?.gte === t
+                            ? "border-[#1a1918] bg-[#1a1918] text-[#faf9f5]"
+                            : "border-[#e5e2da] bg-[#faf9f5] text-[#57534a] hover:border-[#1a1918]"
+                        )}
+                      >
+                        ≥{t}
+                      </button>
+                    ))}
+                    <button
+                      type="button"
+                      onClick={() => set({ filter: null })}
+                      className={cn(
+                        "cursor-pointer rounded-full border px-2.5 py-0.5 font-plex text-[9px] font-bold",
+                        !q.filter
+                          ? "border-[#1a1918] bg-[#1a1918] text-[#faf9f5]"
+                          : "border-[#e5e2da] bg-[#faf9f5] text-[#57534a] hover:border-[#1a1918]"
+                      )}
+                    >
+                      NONE
+                    </button>
+                  </div>
+                  <AttributeMenuItems
+                    current={q.filter?.key ?? null}
+                    onPick={(key) => set({ filter: { key, gte: q.filter?.gte ?? 85 } })}
+                  />
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
+            , ranked by{" "}
+            <DropdownMenu.Root>
+              <SlotTrigger>{sortLabel(q.sortKey)}</SlotTrigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content className={MENU_CONTENT} sideOffset={6} align="start">
+                  <DropdownMenu.Item
+                    className={MENU_ITEM}
+                    onSelect={() => set({ sortKey: "overall", sortDir: "desc" })}
+                  >
+                    overall <Check on={q.sortKey === "overall"} />
+                  </DropdownMenu.Item>
+                  <AttributeMenuItems
+                    current={q.sortKey === "overall" ? null : q.sortKey}
+                    onPick={(key) => set({ sortKey: key, sortDir: "desc" })}
+                  />
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
           </div>
+
           <div className="mt-3.5 flex items-center overflow-hidden rounded-[10px] bg-[#1a1918]">
             <span className="shrink-0 bg-white/12 px-[13px] py-[9px] font-plex text-[9.5px] text-[#faf9f5]">
               GET
@@ -386,35 +510,43 @@ function Playground() {
         </div>
       </div>
 
-      {/* Meta strip */}
-      <div className="mx-auto flex max-w-[1440px] flex-wrap items-center justify-between gap-2.5 px-[clamp(20px,4vw,48px)] pt-3.5">
-        <span className="flex flex-wrap items-center gap-2 font-plex text-[10px] tracking-[0.08em] text-[#8a8577]">
-          <span>
-            <b className="text-[#1a1918]">{players ? `${filtered.length} MATCH` : "LOADING"}</b> ·
-            CACHED 1H
-          </span>
-          {q.team && (
-            <button
-              type="button"
-              onClick={() => setQ((s) => ({ ...s, team: null }))}
-              className="cursor-pointer rounded-full border border-[#e5e2da] bg-white px-2.5 py-0.5 font-plex text-[9px] tracking-[0.08em] text-[#57534a] hover:border-[#1a1918]"
-              title="Clear team filter"
-            >
-              TEAM: {q.team.toUpperCase()} ✕
-            </button>
-          )}
-          {q.search && (
-            <button
-              type="button"
-              onClick={() => setQ((s) => ({ ...s, search: null }))}
-              className="cursor-pointer rounded-full border border-[#e5e2da] bg-white px-2.5 py-0.5 font-plex text-[9px] tracking-[0.08em] text-[#57534a] hover:border-[#1a1918]"
-              title="Clear name search"
-            >
-              NAME: &quot;{q.search.toUpperCase()}&quot; ✕
-            </button>
-          )}
+      {/* Meta strip: count + chips + saved queries + exports */}
+      <div className="mx-auto flex max-w-[1440px] flex-wrap items-center gap-x-4 gap-y-2.5 px-[clamp(20px,4vw,48px)] pt-3.5">
+        <span className="font-plex text-[10px] tracking-[0.08em] text-[#8a8577]">
+          <b className="text-[#1a1918]">{data ? `${data.totalCount} MATCH` : "LOADING"}</b>
+          {updating && " · UPDATING…"}
         </span>
-        <div className="flex gap-2">
+        {q.team && (
+          <button
+            type="button"
+            onClick={() => set({ team: null })}
+            className="cursor-pointer rounded-full border border-[#e5e2da] bg-white px-2.5 py-0.5 font-plex text-[9px] tracking-[0.08em] text-[#57534a] hover:border-[#1a1918]"
+          >
+            TEAM: {q.team.toUpperCase()} ✕
+          </button>
+        )}
+        {q.search && (
+          <button
+            type="button"
+            onClick={() => set({ search: null })}
+            className="cursor-pointer rounded-full border border-[#e5e2da] bg-white px-2.5 py-0.5 font-plex text-[9px] tracking-[0.08em] text-[#57534a] hover:border-[#1a1918]"
+          >
+            NAME: &quot;{q.search.toUpperCase()}&quot; ✕
+          </button>
+        )}
+        <span className="mx-1 hidden h-4 w-px bg-[#e5e2da] sm:block" />
+        <span className="font-plex text-[8.5px] tracking-[0.1em] text-[#b5b0a1]">SAVED</span>
+        {SAVED_QUERIES.map((s) => (
+          <button
+            key={s.label}
+            type="button"
+            onClick={() => setQ(s.state)}
+            className="cursor-pointer rounded-full border border-[#e5e2da] bg-white px-3 py-1 text-[11px] font-semibold text-[#1a1918] transition-[border-color,transform] duration-150 hover:border-[#1a1918] active:scale-[0.97] motion-reduce:transition-none"
+          >
+            {s.label}
+          </button>
+        ))}
+        <div className="ml-auto flex gap-2">
           <button
             type="button"
             onClick={exportCsv}
@@ -432,146 +564,29 @@ function Playground() {
         </div>
       </div>
 
-      {/* Results + rail */}
-      <div className="mx-auto grid max-w-[1440px] grid-cols-[repeat(auto-fit,minmax(min(100%,620px),1fr))] items-start gap-3.5 px-[clamp(20px,4vw,48px)] pt-2.5 pb-12">
-        {/* Table */}
-        <div
-          className="overflow-hidden rounded-[14px] border border-[#e5e2da] bg-white animate-[rise-in_400ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
-          style={{ animationDelay: "80ms" }}
-        >
-          <div className="overflow-x-auto">
-            <div className="min-w-[655px]">
-              <div className={cn(rowGrid, "border-b border-[#e5e2da] bg-[#faf9f5] py-[9px]")}>
-                <span className={cn(monoHead, "text-[#b5b0a1]")}>#</span>
-                <span />
-                <span className={cn(monoHead, "text-[#b5b0a1]")}>PLAYER</span>
-                <span className={cn(monoHead, "text-[#b5b0a1]")}>ERA</span>
-                <button
-                  type="button"
-                  onClick={sortBy("overall")}
-                  className={cn(monoHead, "cursor-pointer text-left font-bold select-none")}
-                  style={{ color: headColor("overall") }}
-                >
-                  OVR{arrow("overall")}
-                </button>
-                <button
-                  type="button"
-                  onClick={sortBy("tpt")}
-                  className={cn(
-                    monoHead,
-                    "cursor-pointer rounded-[5px] bg-[#f6f2e6] py-0.5 text-center font-bold text-[#1a1918] select-none"
-                  )}
-                >
-                  3PT{arrow("tpt")} ●
-                </button>
-                {(["spd", "dnk", "def"] as const).map((key) => (
-                  <button
-                    key={key}
-                    type="button"
-                    onClick={sortBy(key)}
-                    className={cn(
-                      monoHead,
-                      "cursor-pointer text-center transition-colors duration-150 select-none hover:text-[#1a1918]"
-                    )}
-                    style={{ color: headColor(key) }}
-                  >
-                    {key.toUpperCase()}
-                    {arrow(key)}
-                  </button>
-                ))}
-              </div>
-
-              {players
-                ? rows.map((p, i) => {
-                    const era = eraTag(p.teamType);
-                    return (
-                      <Link
-                        key={`${p.slug}-${p.teamType}-${p.team}`}
-                        href={`/players/${p.slug}?type=${p.teamType}&team=${encodeURIComponent(p.team)}`}
-                        className={cn(
-                          rowGrid,
-                          "border-b border-[#faf8f2] py-[7px] text-[#1a1918] no-underline transition-colors duration-100 hover:bg-[#faf8f2]"
-                        )}
-                      >
-                        <span className="font-plex text-[10px] text-[#b5b0a1]">{i + 1}</span>
-                        <Headshot src={p.playerImage} name={p.name} size={28} />
-                        <div className="flex min-w-0 items-baseline gap-2">
-                          <span className="overflow-hidden text-[13px] font-semibold text-ellipsis whitespace-nowrap">
-                            {p.name}
-                          </span>
-                          <span className="whitespace-nowrap font-plex text-[8.5px] text-[#8a8577]">
-                            {p.positions.join("/")} · {shortTeam(p)}
-                          </span>
-                        </div>
-                        <span
-                          className="font-plex text-[8px] font-bold tracking-[0.08em]"
-                          style={{ color: era.color }}
-                        >
-                          {era.label}
-                        </span>
-                        <OvrChip ovr={p.overall} />
-                        <AttrCell value={p.threePointShot} highlighted />
-                        <AttrCell value={p.speed} />
-                        <AttrCell value={p.drivingDunk} />
-                        <AttrCell value={p.perimeterDefense} />
-                      </Link>
-                    );
-                  })
-                : Array.from({ length: 12 }, (_, i) => (
-                    <div
-                      key={i}
-                      className={cn(rowGrid, "animate-pulse border-b border-[#faf8f2] py-[7px]")}
-                    >
-                      <span className="h-3 w-4 rounded bg-[#f1efe8]" />
-                      <div className="h-7 w-7 rounded-full bg-[#f1efe8]" />
-                      <span className="h-3.5 w-2/3 rounded bg-[#f1efe8]" />
-                      <span className="h-3 w-12 rounded bg-[#f1efe8]" />
-                      <span className="h-[22px] w-[38px] rounded-[6px] bg-[#f1efe8]" />
-                      <span className="h-[22px] rounded-[5px] bg-[#f1efe8]" />
-                      <span className="h-3 rounded bg-[#f1efe8]" />
-                      <span className="h-3 rounded bg-[#f1efe8]" />
-                      <span className="h-3 rounded bg-[#f1efe8]" />
-                    </div>
-                  ))}
-
-              {players && rows.length === 0 && (
-                <div className="px-4 py-10 text-center">
-                  <div className="font-display text-[17px] font-bold">No players match</div>
-                  <div className="mt-1 text-[12.5px] text-[#8a8577]">
-                    Loosen a slot — try &quot;any 3PT&quot; or &quot;any era&quot;.
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
-          <div className="flex flex-wrap items-center justify-between gap-2 bg-[#faf9f5] px-4 py-2">
-            <span className="font-plex text-[8.5px] text-[#b5b0a1]">
-              ● = QUERIED COLUMN · CLICK A COLUMN TO SORT · CLICK A ROW → DOSSIER
+      {/* Response drawer — visible, above the table */}
+      <div className="mx-auto max-w-[1440px] px-[clamp(20px,4vw,48px)] pt-2.5">
+        <div className="overflow-hidden rounded-[12px] bg-[#1a1918]">
+          <button
+            type="button"
+            onClick={() => setResponseOpen((o) => !o)}
+            className="flex w-full cursor-pointer items-center gap-3 px-4 py-2"
+          >
+            <span className="font-plex text-[9px] tracking-[0.1em] text-white/60">RESPONSE</span>
+            <span className="font-plex text-[8.5px] text-[#6ee7a0]">
+              {data ? `200 OK · ${data.totalCount} RESULTS` : "LOADING…"}
             </span>
-            <span className="font-plex text-[8.5px] text-[#b5b0a1]">
-              SHOWING {rows.length} OF {filtered.length}
+            <span className="ml-auto font-plex text-[8.5px] text-white/60">
+              {responseOpen ? "▾ HIDE JSON" : "▸ VIEW JSON"}
             </span>
-          </div>
-        </div>
-
-        {/* Right rail */}
-        <div
-          className="flex flex-col gap-2.5 animate-[rise-in_400ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
-          style={{ animationDelay: "140ms" }}
-        >
-          <div className="rounded-[14px] bg-[#1a1918] px-4 py-3.5">
-            <div className="mb-2.5 flex items-center justify-between">
-              <span className="font-plex text-[9px] tracking-[0.1em] text-white/60">RESPONSE</span>
-              <span className="font-plex text-[8.5px] text-[#6ee7a0]">
-                {players ? "200 OK · LIVE" : "LOADING…"}
-              </span>
-            </div>
-            <pre className="m-0 overflow-hidden font-plex text-[10px] leading-[1.65] text-white/85">
+          </button>
+          {responseOpen && (
+            <pre className="m-0 overflow-x-auto border-t border-white/10 px-4 py-3 font-plex text-[10px] leading-[1.65] text-white/85">
               {"{\n  "}
               <span className="text-[#8ab4f8]">&quot;success&quot;</span>
               {": true,\n  "}
               <span className="text-[#8ab4f8]">&quot;count&quot;</span>
-              {`: ${filtered.length},\n  `}
+              {`: ${data?.totalCount ?? 0},\n  `}
               <span className="text-[#8ab4f8]">&quot;results&quot;</span>
               {": [\n"}
               {first ? (
@@ -589,55 +604,95 @@ function Playground() {
                   {": "}
                   <span className="text-[#b79ce0]">{first.overall}</span>
                   {",\n      "}
-                  <span className="text-[#8ab4f8]">&quot;three_ball&quot;</span>
+                  <span className="text-[#8ab4f8]">&quot;attributes&quot;</span>
+                  {": { "}
+                  <span className="text-[#8ab4f8]">&quot;threePointShot&quot;</span>
                   {": "}
-                  <span className="text-[#b79ce0]">{first.threePointShot ?? "null"}</span>
-                  {",\n      "}
-                  <span className="text-[#8ab4f8]">&quot;era&quot;</span>
-                  {": "}
-                  <span className="text-[#e6b36a]">&quot;{first.teamType}&quot;</span>
-                  {"\n    },\n    "}
-                  <span className="text-white/40">…{Math.max(0, filtered.length - 1)} more</span>
+                  <span className="text-[#b79ce0]">
+                    {first.attributes?.threePointShot ?? "null"}
+                  </span>
+                  {", "}
+                  <span className="text-white/40">
+                    …{Object.keys(first.attributes ?? {}).length} fields
+                  </span>
+                  {" }\n    },\n    "}
+                  <span className="text-white/40">
+                    …{Math.max(0, (data?.totalCount ?? 1) - 1)} more
+                  </span>
                   {"\n"}
                 </>
               ) : (
                 <span className="text-white/40">{"    …\n"}</span>
               )}
-              {"  ]\n}"}
+              {"  ],\n  "}
+              <span className="text-[#8ab4f8]">&quot;meta&quot;</span>
+              {": { "}
+              <span className="text-[#8ab4f8]">&quot;pagination&quot;</span>
+              {`: { `}
+              <span className="text-[#8ab4f8]">&quot;total&quot;</span>
+              {`: ${data?.totalCount ?? 0}, `}
+              <span className="text-[#8ab4f8]">&quot;limit&quot;</span>
+              {`: ${PAGE_SIZE} } }\n}`}
             </pre>
-          </div>
+          )}
+        </div>
+      </div>
 
-          <div className="rounded-[14px] border border-[#e5e2da] bg-white px-4 py-3">
-            <div className="mb-2 font-plex text-[9px] tracking-[0.1em] text-[#8a8577]">
-              TRIM THE PAYLOAD
-            </div>
-            <p className="m-0 text-[11.5px] leading-[1.5] text-[#57534a]">
-              Add{" "}
-              <span className="rounded-[5px] border border-[#e5e2da] bg-[#faf9f5] px-[5px] py-px font-plex text-[10px]">
-                ?fields=name,overall
-              </span>{" "}
-              to get only the columns you need.
-            </p>
-          </div>
-
-          <div className="rounded-[14px] border border-[#e5e2da] bg-white px-4 py-3">
-            <div className="mb-2 font-plex text-[9px] tracking-[0.1em] text-[#8a8577]">
-              SAVED QUERIES
-            </div>
-            <div className="flex flex-col items-start gap-1.5">
-              {SAVED_QUERIES.map((s) => (
-                <button
-                  key={s.label}
-                  type="button"
-                  onClick={() => applySaved(s)}
-                  className="cursor-pointer text-left text-[11.5px] font-semibold text-[#1a1918] transition-colors duration-150 hover:text-[#57534a]"
-                >
-                  {s.label}
-                </button>
-              ))}
+      {/* Full-attribute table */}
+      <div className="mx-auto max-w-[1440px] px-[clamp(20px,4vw,48px)] pt-2.5 pb-12">
+        <div
+          className={cn(
+            "overflow-hidden rounded-[14px] border border-[#e5e2da] bg-white transition-opacity duration-150",
+            updating && "opacity-60"
+          )}
+        >
+          <PlayerTable
+            players={data?.players ?? []}
+            rankOffset={q.page * PAGE_SIZE}
+            queriedKey={q.filter?.key ?? null}
+            sortKey={q.sortKey}
+            sortDir={q.sortDir}
+            onSort={onSort}
+            playerHref={(p) =>
+              `/players/${p.slug}?type=${p.teamType}&team=${encodeURIComponent(p.team)}`
+            }
+            emptyText="NO PLAYERS MATCH — LOOSEN A SLOT"
+            loading={!data}
+          />
+          <div className="flex flex-wrap items-center justify-between gap-2 border-t border-[#f1efe8] bg-[#faf9f5] px-4 py-2">
+            <span className="font-plex text-[8.5px] text-[#b5b0a1]">
+              {q.filter ? "TINTED = QUERIED COLUMN · " : ""}CLICK ANY COLUMN TO SORT · CLICK A
+              PLAYER → DOSSIER
+            </span>
+            <div className="flex items-center gap-2.5">
+              <button
+                type="button"
+                disabled={q.page === 0}
+                onClick={() => setQ((s) => ({ ...s, page: Math.max(0, s.page - 1) }))}
+                className="cursor-pointer rounded-full border border-[#e5e2da] bg-white px-2.5 py-0.5 font-plex text-[9px] font-bold text-[#57534a] disabled:cursor-default disabled:opacity-40 [&:not(:disabled)]:hover:border-[#1a1918]"
+              >
+                ‹ PREV
+              </button>
+              <span className="font-plex text-[8.5px] text-[#8a8577]">
+                {data
+                  ? `SHOWING ${data.totalCount === 0 ? 0 : q.page * PAGE_SIZE + 1}–${Math.min((q.page + 1) * PAGE_SIZE, data.totalCount)} OF ${data.totalCount} · PAGE ${Math.min(q.page + 1, totalPages)}/${totalPages}`
+                  : "…"}
+              </span>
+              <button
+                type="button"
+                disabled={!data?.hasMore}
+                onClick={() => setQ((s) => ({ ...s, page: s.page + 1 }))}
+                className="cursor-pointer rounded-full border border-[#e5e2da] bg-white px-2.5 py-0.5 font-plex text-[9px] font-bold text-[#57534a] disabled:cursor-default disabled:opacity-40 [&:not(:disabled)]:hover:border-[#1a1918]"
+              >
+                NEXT ›
+              </button>
             </div>
           </div>
         </div>
+        <p className="mt-2.5 mb-0 font-plex text-[8.5px] text-[#b5b0a1]">
+          TIP: ADD <code className="text-[#8a8577]">?fields=name,overall</code> TO ANY CALL TO TRIM
+          THE PAYLOAD.
+        </p>
       </div>
 
       <FooterStrip width="wide" />

--- a/components/ui/player-table.tsx
+++ b/components/ui/player-table.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import Link from "next/link";
+import { Headshot } from "@/components/ui/headshot";
+import { getRatingClasses, getAttributeColor } from "@/lib/rating-colors";
+import { getTeamAbbreviation } from "@/lib/team-abbr";
+import {
+  ATTRIBUTE_SHORT_LABELS,
+  CATEGORY_SHORT_LABELS,
+  ORDERED_ATTRIBUTES,
+} from "@/lib/attribute-labels";
+import { getAttributeDisplayName } from "@/lib/attribute-normalizer";
+import { cn } from "@/lib/utils";
+
+type TeamType = "curr" | "class" | "allt";
+
+export type TablePlayer = {
+  name: string;
+  slug: string;
+  team: string;
+  teamType: TeamType;
+  positions?: string[];
+  height?: string | null;
+  overall: number;
+  playerImage?: string | null;
+  attributes?: Record<string, number>;
+};
+
+function shortTeam(p: TablePlayer): string {
+  const abbr = getTeamAbbreviation(p.team);
+  if (p.teamType === "class") {
+    const match = p.team.match(/^\d{4}-(\d{2})\s/);
+    return match ? `${abbr} '${match[1]}` : abbr;
+  }
+  if (p.teamType === "allt") return `${abbr} A-T`;
+  return abbr;
+}
+
+function eraTag(teamType: TeamType) {
+  if (teamType === "class") return { label: "CLASSIC", color: "#9a6700" };
+  if (teamType === "allt") return { label: "ALL-TIME", color: "#9a6700" };
+  return { label: "CURRENT", color: "#8a8577" };
+}
+
+/**
+ * Full-attribute player table: sticky player column, every attribute as a
+ * color-coded column, horizontal scroll. Shared by the playground results
+ * and team rosters (taste ruling: show ALL the information).
+ */
+export function PlayerTable({
+  players,
+  rankOffset = 0,
+  queriedKey,
+  sortKey,
+  sortDir,
+  onSort,
+  playerHref,
+  emptyText = "NO PLAYERS MATCH",
+  loading = false,
+}: {
+  players: TablePlayer[];
+  rankOffset?: number;
+  /** Attribute column to tint as "the queried column". */
+  queriedKey?: string | null;
+  /** Current sort: "overall" or an attribute key. */
+  sortKey?: string;
+  sortDir?: "asc" | "desc";
+  onSort?: (key: string) => void;
+  playerHref: (p: TablePlayer) => string;
+  emptyText?: string;
+  loading?: boolean;
+}) {
+  const arrow = (key: string) => (sortKey === key ? (sortDir === "asc" ? " ↑" : " ↓") : "");
+
+  const headBtn = (key: string, label: string, extra?: string) => (
+    <button
+      type="button"
+      onClick={onSort ? () => onSort(key) : undefined}
+      title={key === "overall" ? "Overall" : getAttributeDisplayName(key)}
+      className={cn(
+        "w-full cursor-pointer text-center font-plex text-[8px] tracking-[0.04em] whitespace-nowrap transition-colors duration-150 select-none",
+        sortKey === key ? "font-bold text-[#1a1918]" : "text-[#b5b0a1] hover:text-[#1a1918]",
+        extra
+      )}
+    >
+      {label}
+      {arrow(key)}
+    </button>
+  );
+
+  // Category group boundaries for the top header band
+  const groups: { category: string; span: number }[] = [];
+  for (const { category } of ORDERED_ATTRIBUTES) {
+    const last = groups[groups.length - 1];
+    if (last && last.category === category) last.span++;
+    else groups.push({ category, span: 1 });
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse" style={{ minWidth: 720 + ORDERED_ATTRIBUTES.length * 44 }}>
+        <thead>
+          <tr>
+            <th className="sticky left-0 z-[3] border-b border-[#e5e2da] bg-[#faf9f5]" colSpan={2} />
+            <th className="border-b border-[#e5e2da] bg-[#faf9f5]" colSpan={2} />
+            {groups.map((g) => (
+              <th
+                key={g.category}
+                colSpan={g.span}
+                className="border-b border-l border-[#e5e2da] bg-[#faf9f5] px-1 py-1 text-center font-plex text-[7px] font-normal tracking-[0.1em] text-[#b5b0a1]"
+              >
+                {CATEGORY_SHORT_LABELS[g.category]}
+              </th>
+            ))}
+          </tr>
+          <tr>
+            <th className="sticky left-0 z-[3] w-[220px] min-w-[220px] border-b border-[#e5e2da] bg-[#faf9f5] px-4 py-2 text-left font-plex text-[8.5px] font-normal tracking-[0.08em] text-[#b5b0a1] shadow-[4px_0_8px_-4px_rgba(26,25,24,0.08)]">
+              PLAYER
+            </th>
+            <th className="w-[52px] border-b border-[#e5e2da] bg-[#faf9f5] px-1 py-2 font-plex text-[8.5px] font-normal tracking-[0.08em] text-[#b5b0a1]">
+              POS
+            </th>
+            <th className="w-[44px] border-b border-[#e5e2da] bg-[#faf9f5] px-1 py-2 font-plex text-[8.5px] font-normal tracking-[0.08em] text-[#b5b0a1]">
+              HT
+            </th>
+            <th className="w-[52px] border-b border-[#e5e2da] bg-[#faf9f5] px-1 py-2">
+              {headBtn("overall", "OVR")}
+            </th>
+            {ORDERED_ATTRIBUTES.map(({ key }) => (
+              <th
+                key={key}
+                className={cn(
+                  "w-[44px] border-b border-[#e5e2da] bg-[#faf9f5] px-0.5 py-2",
+                  queriedKey === key && "bg-[#f6f2e6]"
+                )}
+              >
+                {headBtn(key, ATTRIBUTE_SHORT_LABELS[key] ?? key.slice(0, 3).toUpperCase())}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {loading
+            ? Array.from({ length: 10 }, (_, i) => (
+                <tr key={i} className="animate-pulse border-b border-[#faf8f2]">
+                  <td className="sticky left-0 z-[2] bg-white px-4 py-2">
+                    <div className="flex items-center gap-2.5">
+                      <div className="h-7 w-7 rounded-full bg-[#f1efe8]" />
+                      <div className="h-3.5 w-32 rounded bg-[#f1efe8]" />
+                    </div>
+                  </td>
+                  <td colSpan={3 + ORDERED_ATTRIBUTES.length}>
+                    <div className="mx-4 h-3 rounded bg-[#f1efe8]" />
+                  </td>
+                </tr>
+              ))
+            : players.map((p, i) => {
+                const era = eraTag(p.teamType);
+                return (
+                  <tr key={`${p.slug}-${p.teamType}-${p.team}`} className="group border-b border-[#faf8f2]">
+                    <td className="sticky left-0 z-[2] bg-white px-4 py-1.5 shadow-[4px_0_8px_-4px_rgba(26,25,24,0.08)] group-hover:bg-[#faf8f2]">
+                      <Link
+                        href={playerHref(p)}
+                        className="flex min-w-0 items-center gap-2.5 text-[#1a1918] no-underline"
+                      >
+                        <span className="w-6 shrink-0 font-plex text-[9px] text-[#b5b0a1]">
+                          {rankOffset + i + 1}
+                        </span>
+                        <Headshot src={p.playerImage} name={p.name} size={28} />
+                        <span className="min-w-0">
+                          <span className="block overflow-hidden text-[12.5px] font-semibold text-ellipsis whitespace-nowrap">
+                            {p.name}
+                          </span>
+                          <span
+                            className="block font-plex text-[7.5px] tracking-[0.06em]"
+                            style={{ color: era.color }}
+                          >
+                            {shortTeam(p)} · {era.label}
+                          </span>
+                        </span>
+                      </Link>
+                    </td>
+                    <td className="px-1 py-1.5 text-center font-plex text-[9px] whitespace-nowrap text-[#57534a] group-hover:bg-[#faf8f2]">
+                      {(p.positions ?? []).join("/")}
+                    </td>
+                    <td className="px-1 py-1.5 text-center font-plex text-[9px] whitespace-nowrap text-[#57534a] group-hover:bg-[#faf8f2]">
+                      {p.height ?? "—"}
+                    </td>
+                    <td className="px-1 py-1.5 text-center group-hover:bg-[#faf8f2]">
+                      <span
+                        className={cn(
+                          "inline-flex w-[34px] items-center justify-center rounded-[6px] py-[3px] text-[11.5px] font-bold text-white tabular-nums",
+                          getRatingClasses(p.overall).bg
+                        )}
+                      >
+                        {p.overall}
+                      </span>
+                    </td>
+                    {ORDERED_ATTRIBUTES.map(({ key }) => {
+                      const v = p.attributes?.[key];
+                      return (
+                        <td
+                          key={key}
+                          className={cn(
+                            "px-0.5 py-1.5 text-center text-[11.5px] font-bold tabular-nums group-hover:bg-[#faf8f2]",
+                            queriedKey === key && "bg-[#faf7ee]"
+                          )}
+                          style={{ color: typeof v === "number" ? getAttributeColor(v) : "#d9d4c7" }}
+                        >
+                          {typeof v === "number" ? v : "—"}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+          {!loading && players.length === 0 && (
+            <tr>
+              <td
+                colSpan={4 + ORDERED_ATTRIBUTES.length}
+                className="px-4 py-10 text-center font-plex text-[9px] tracking-[0.08em] text-[#b5b0a1]"
+              >
+                {emptyText}
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/lib/attribute-labels.ts
+++ b/lib/attribute-labels.ts
@@ -1,0 +1,61 @@
+/**
+ * Compact column labels for the full-attribute tables, in category order.
+ */
+
+import { ATTRIBUTE_CATEGORIES } from "@/convex/attributeCategories";
+
+export const ATTRIBUTE_SHORT_LABELS: Record<string, string> = {
+  closeShot: "CLS",
+  midRangeShot: "MID",
+  threePointShot: "3PT",
+  freeThrow: "FT",
+  shotIQ: "SIQ",
+  offensiveConsistency: "OCN",
+  drivingLayup: "LAY",
+  standingDunk: "SDK",
+  drivingDunk: "DNK",
+  postHook: "HK",
+  postFade: "FD",
+  postControl: "PST",
+  drawFoul: "DRW",
+  hands: "HND",
+  passAccuracy: "PAC",
+  ballHandle: "BH",
+  speedWithBall: "SWB",
+  passIQ: "PIQ",
+  passVision: "VIS",
+  passPerception: "PPR",
+  passing: "PSS",
+  postMoves: "PMV",
+  interiorDefense: "ID",
+  perimeterDefense: "PD",
+  steal: "STL",
+  block: "BLK",
+  defensiveConsistency: "DCN",
+  defensiveRebound: "DRB",
+  lateralQuickness: "LAT",
+  helpDefenseIQ: "HDQ",
+  speed: "SPD",
+  acceleration: "ACC",
+  agility: "AGI",
+  vertical: "VRT",
+  strength: "STR",
+  stamina: "STA",
+  hustle: "HSL",
+  durability: "DUR",
+  offensiveRebound: "ORB",
+};
+
+/** All attribute keys in category order, with their category for group headers. */
+export const ORDERED_ATTRIBUTES: { key: string; category: string }[] = (
+  Object.entries(ATTRIBUTE_CATEGORIES) as [string, readonly string[]][]
+).flatMap(([category, keys]) => keys.map((key) => ({ key, category })));
+
+export const CATEGORY_SHORT_LABELS: Record<string, string> = {
+  outsideScoring: "OUTSIDE",
+  insideScoring: "INSIDE",
+  playmaking: "PLAYMAKING",
+  athleticism: "ATHLETICISM",
+  defending: "DEFENDING",
+  rebounding: "REB",
+};


### PR DESCRIPTION
Second PR from the review pass — the playground rework.

- **Slots are dropdowns now**, not click-cycles: position (groups + exact PG–C), era (including all-time), an attribute menu covering all 39 attributes grouped by category with a threshold row (60–95 / NONE), and rank-by-any-attribute. The sentence still reads like a sentence; every slot writes a real API parameter.
- **Server-side querying with pagination**: results come from `getAllFiltered` with limit/offset — PREV/NEXT controls, "SHOWING 51–100 OF 231 · PAGE 2/5", cursor mirrored in the URL so pages are shareable. The previous page stays rendered (dimmed) while the next loads.
- **Every attribute in the table**: new shared `PlayerTable` (also destined for team rosters in the next PR) with a sticky player column, category band headers, all values color-coded, horizontal scroll, queried-column tint, and click-any-column sorting.
- **Response is visible**: a collapsible dark drawer directly above the table always shows `200 OK · N RESULTS`; expanding reveals the JSON shape. Saved queries are chips in the meta strip instead of a buried card.
- **Exports are complete**: CSV/JSON pull the full match set (all attributes), not just the visible page.

Verified in browser: dropdown picks (BLK ≥ 85 → `block_gte=85`, 1 match), pagination with URL cursor, header sort by speed, JSON drawer, saved-query chips, deep links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)