### PR TITLE
chore: strip explanatory helper text from labels

### DIFF
--- a/app/lineups/page.tsx
+++ b/app/lineups/page.tsx
@@ -650,8 +650,7 @@ function Whiteboard() {
                 )}
               </div>
               <div className="px-4 py-[9px] font-plex text-[8px] leading-[1.6] text-[#b5b0a1]">
-                DRAG ONTO A SLOT (OR TAP: FILLS YOUR SPOT, THEN THEIRS) · TAP A PLACED CHIP TO
-                REMOVE · DRAG A CHIP OFF-COURT TO CLEAR IT
+                DRAG OR TAP TO PLACE · TAP A CHIP TO REMOVE
               </div>
             </div>
 

--- a/app/players/[slug]/page.tsx
+++ b/app/players/[slug]/page.tsx
@@ -726,7 +726,7 @@ function PlayerDossier() {
           style={{ animationDelay: "320ms" }}
         >
           <div className={cn(CARD_LABEL, "mb-3")}>
-            FULL ATTRIBUTE MATRIX — 40+ FIELDS, ALL FROM ONE CALL · HOVER FOR THE POSITION AVERAGE
+            FULL ATTRIBUTE MATRIX — 40+ FIELDS, ALL FROM ONE CALL
           </div>
           <div className="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-3.5">
             {Object.entries(ATTRIBUTE_CATEGORIES).map(([cat, keys]) => {

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -389,10 +389,7 @@ function Playground() {
         <div className="rounded-2xl border border-[#e5e2da] bg-white p-[clamp(16px,2.5vw,24px)]">
           <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
             <span className="font-plex text-[9.5px] tracking-[0.12em] text-[#8a8577]">
-              QUERY — OPEN ANY SLOT TO CHANGE IT
-            </span>
-            <span className="font-plex text-[9px] text-[#b5b0a1]">
-              EVERY SLOT MAPS TO AN API PARAMETER
+              QUERY
             </span>
           </div>
 

--- a/app/teams/[slug]/page.tsx
+++ b/app/teams/[slug]/page.tsx
@@ -344,11 +344,7 @@ function TeamPage() {
               className="mt-[26px] flex flex-wrap items-center justify-between gap-3 animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
               style={{ animationDelay: "120ms" }}
             >
-              <span className="font-plex text-[9.5px] tracking-[0.12em] text-[#8a8577]">
-                {view === "depth"
-                  ? "STARTERS BY POSITION — THE BENCH RUNS FLAT, HIGHEST TO LOWEST"
-                  : "FULL ROSTER — EVERY COLUMN MAPS TO AN API FIELD"}
-              </span>
+              <span />
               <div className="flex gap-[3px] rounded-full border border-[#e5e2da] bg-white p-1">
                 {(["depth", "table"] as const).map((v) => (
                   <button
@@ -434,13 +430,8 @@ function TeamPage() {
                     className="mt-4 animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
                     style={{ animationDelay: "260ms" }}
                   >
-                    <div className="mb-2.5 flex items-center justify-between">
-                      <span className="font-plex text-[9px] tracking-[0.12em] text-[#8a8577]">
-                        THE BENCH — LEFT TO RIGHT, HIGHEST TO LOWEST
-                      </span>
-                      <span className="font-plex text-[8.5px] text-[#b5b0a1]">
-                        POSITIONS ARE TAGS, NOT SLOTS
-                      </span>
+                    <div className="mb-2.5 font-plex text-[9px] tracking-[0.12em] text-[#8a8577]">
+                      THE BENCH
                     </div>
                     <div className="grid grid-cols-[repeat(auto-fill,minmax(225px,1fr))] gap-1.5">
                       {bench.map((p, i) => (


### PR DESCRIPTION
Taste ruling: labels name the thing, they don't explain it. Removed the descriptive suffixes and standalone explainer captions across team page, playground, dossier, and whiteboard ("THE BENCH" stands alone now, view-toggle note gone, "QUERY" stands alone, hover-instruction dropped, whiteboard pool hint shortened to "DRAG OR TAP TO PLACE · TAP A CHIP TO REMOVE"). Functional legends (queried-column tint, tier thresholds) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)