### PR TITLE
fix: challenge-aware scraping for 2kratings sgcaptcha + write-free CI probe

### DIFF
--- a/.github/workflows/scrape-debug.yml
+++ b/.github/workflows/scrape-debug.yml
@@ -1,0 +1,21 @@
+name: Scrape anti-bot diagnostic
+
+# Write-free probe: runs the scraper's browser stack against 2kratings from a
+# GitHub runner and reports whether the sgcaptcha challenge auto-solves.
+# No secrets, no Convex writes.
+on:
+  workflow_dispatch:
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Run probe (headed under xvfb, same as the real scrape)
+        run: xvfb-run --auto-servernum node scripts/debugChallenge.mjs

--- a/scraper/playerScraper.js
+++ b/scraper/playerScraper.js
@@ -5,7 +5,7 @@
  */
 
 import { SCRAPER_OPTIONS } from './config.js';
-import { normalizeUrl, logProgress, logError, delay, slugify } from './utils.js';
+import { normalizeUrl, logProgress, logError, delay, slugify , gotoThroughChallenge } from './utils.js';
 
 /**
  * Scrape detailed player data from individual player page
@@ -22,7 +22,7 @@ export async function scrapePlayerDetails(page, basicPlayer) {
   const playerUrl = normalizeUrl(basicPlayer.playerUrl);
 
   try {
-    await page.goto(playerUrl, { waitUntil: SCRAPER_OPTIONS.waitUntil });
+    await gotoThroughChallenge(page, playerUrl);
 
     // Scrape all player details using the ACTUAL HTML structure
     const playerDetails = await page.evaluate(() => {

--- a/scraper/teamScraper.js
+++ b/scraper/teamScraper.js
@@ -4,7 +4,7 @@
  */
 
 import { BASE_URL, TEAM_SELECTORS, TEAM_TYPES, SCRAPER_OPTIONS } from './config.js';
-import { normalizeUrl, logProgress, logError, delay, parseIntSafe } from './utils.js';
+import { normalizeUrl, logProgress, logError, delay, parseIntSafe, gotoThroughChallenge } from './utils.js';
 
 /**
  * Scrape team links from the team listing page
@@ -21,7 +21,7 @@ export async function scrapeTeamLinks(page, teamType) {
   const url = `${BASE_URL}${config.url}`;
   logProgress(`Navigating to ${config.name} teams: ${url}`);
 
-  await page.goto(url, { waitUntil: SCRAPER_OPTIONS.waitUntil });
+  await gotoThroughChallenge(page, url);
 
   // Extract team links from the page
   const teams = await page.$$eval(TEAM_SELECTORS.teamLinks, (links) => {
@@ -57,7 +57,7 @@ export async function scrapeTeamRoster(page, team, teamType) {
   try {
     logProgress(`Scraping roster: ${team.teamName}`);
 
-    await page.goto(teamUrl, { waitUntil: SCRAPER_OPTIONS.waitUntil });
+    await gotoThroughChallenge(page, teamUrl);
 
     // Extract player data from roster table
     const players = await page.$$eval(

--- a/scraper/utils.js
+++ b/scraper/utils.js
@@ -76,6 +76,9 @@ export async function createPage(browser) {
 const CHALLENGE_PATH = '/.well-known/sgcaptcha';
 
 export async function gotoThroughChallenge(page, url, retries = 3) {
+  const samePage = () =>
+    page.url().split('?')[0].replace(/\/$/, '') === url.split('?')[0].replace(/\/$/, '');
+
   for (let attempt = 1; attempt <= retries; attempt++) {
     try {
       await page.goto(url, { waitUntil: SCRAPER_OPTIONS.waitUntil });
@@ -92,8 +95,14 @@ export async function gotoThroughChallenge(page, url, retries = 3) {
     if (!page.url().includes(CHALLENGE_PATH)) {
       await page.waitForTimeout(500);
     }
+
     if (!page.url().includes(CHALLENGE_PATH)) {
-      return; // on the target page
+      if (samePage()) {
+        return;
+      }
+      // Escaped the challenge but on the wrong page (stale r= bounce or a
+      // superseded navigation) — re-goto the target.
+      continue;
     }
 
     logProgress(
@@ -104,11 +113,11 @@ export async function gotoThroughChallenge(page, url, retries = 3) {
         timeout: 35000,
       });
       await page.waitForLoadState('domcontentloaded').catch(() => {});
-      // Challenge solved and cookie set. If it bounced us to a different page
-      // than requested (its r= target can be a previous URL), loop to re-goto.
-      if (page.url().split('?')[0].replace(/\/$/, '') === url.split('?')[0].replace(/\/$/, '')) {
+      if (samePage()) {
         return;
       }
+      // Challenge solved (cookie now set) but bounced elsewhere — loop to
+      // re-goto the target.
     } catch {
       // Challenge never auto-resolved — capture what it showed for forensics.
       const title = await page.title().catch(() => '?');

--- a/scraper/utils.js
+++ b/scraper/utils.js
@@ -65,6 +65,66 @@ export async function createPage(browser) {
 }
 
 /**
+ * SiteGround's anti-bot layer ("sgcaptcha") intercepts navigations from
+ * low-reputation IPs and redirects to /.well-known/sgcaptcha/?r=<target>.
+ * In a real (headed) browser the challenge is a JS check that auto-solves,
+ * sets a cookie on the context, and redirects back to <target>. This wrapper
+ * makes every navigation challenge-aware: detect the redirect, wait for the
+ * auto-solve, and retry the target. Cookies persist on the shared context, so
+ * one solved challenge usually covers the rest of the run.
+ */
+const CHALLENGE_PATH = '/.well-known/sgcaptcha';
+
+export async function gotoThroughChallenge(page, url, retries = 3) {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      await page.goto(url, { waitUntil: SCRAPER_OPTIONS.waitUntil });
+    } catch (error) {
+      // The challenge redirect can interrupt the navigation itself; that is
+      // not fatal — fall through and handle whatever page we landed on.
+      if (!String(error.message).includes('interrupted by another navigation')) {
+        throw error;
+      }
+      await page.waitForLoadState('domcontentloaded').catch(() => {});
+    }
+
+    // Give a just-issued challenge redirect a beat to land.
+    if (!page.url().includes(CHALLENGE_PATH)) {
+      await page.waitForTimeout(500);
+    }
+    if (!page.url().includes(CHALLENGE_PATH)) {
+      return; // on the target page
+    }
+
+    logProgress(
+      `Anti-bot challenge intercepted ${url} (attempt ${attempt}/${retries}) — waiting for it to solve…`
+    );
+    try {
+      await page.waitForURL((u) => !u.toString().includes(CHALLENGE_PATH), {
+        timeout: 35000,
+      });
+      await page.waitForLoadState('domcontentloaded').catch(() => {});
+      // Challenge solved and cookie set. If it bounced us to a different page
+      // than requested (its r= target can be a previous URL), loop to re-goto.
+      if (page.url().split('?')[0].replace(/\/$/, '') === url.split('?')[0].replace(/\/$/, '')) {
+        return;
+      }
+    } catch {
+      // Challenge never auto-resolved — capture what it showed for forensics.
+      const title = await page.title().catch(() => '?');
+      const snippet = await page
+        .evaluate(() => document.body?.innerText?.slice(0, 300) ?? '')
+        .catch(() => '');
+      logError(
+        `Challenge did not auto-resolve on attempt ${attempt} (title: "${title}"): ${snippet.replace(/\s+/g, ' ')}`
+      );
+      await delay(5000 * attempt);
+    }
+  }
+  throw new Error(`Blocked by anti-bot challenge after ${retries} attempts: ${url}`);
+}
+
+/**
  * Normalize URL - convert relative URLs to absolute
  * @param {string} url - URL to normalize
  * @returns {string} Absolute URL

--- a/scripts/debugChallenge.mjs
+++ b/scripts/debugChallenge.mjs
@@ -1,0 +1,35 @@
+/**
+ * Write-free anti-bot diagnostic: drives the exact scraper browser stack
+ * against 2kratings from wherever it runs (CI runner or local) and reports
+ * whether the sgcaptcha challenge fires and whether it auto-solves.
+ * No Convex, no writes — safe to run anywhere.
+ */
+import { initBrowser, createPage, gotoThroughChallenge } from '../scraper/utils.js';
+import { BASE_URL, TEAM_SELECTORS } from '../scraper/config.js';
+
+const targets = [
+  `${BASE_URL}/teams`,
+  `${BASE_URL}/teams/atlanta-hawks`,
+  `${BASE_URL}/teams/boston-celtics`,
+];
+
+const browser = await initBrowser();
+const page = await createPage(browser);
+let failures = 0;
+
+for (const url of targets) {
+  const started = Date.now();
+  try {
+    await gotoThroughChallenge(page, url);
+    const rows = await page.$$(TEAM_SELECTORS.playerRows ?? 'body');
+    console.log(
+      `OK  ${url} → ${page.url()} (${Date.now() - started}ms, ${rows.length} row nodes, title: "${await page.title()}")`
+    );
+  } catch (error) {
+    failures++;
+    console.error(`FAIL ${url} after ${Date.now() - started}ms: ${error.message}`);
+  }
+}
+
+await browser.close();
+process.exit(failures > 0 ? 1 : 0);


### PR DESCRIPTION
## Why the pipeline broke

The Jul 4 scheduled scrape failed with every team bounced to SiteGround's `/.well-known/sgcaptcha` challenge — a new anti-bot layer that gates datacenter IPs (GitHub runners). Residential IPs pass with no challenge at all (verified locally). Prod data has been frozen at Jun 29 since.

## What this does

- All scraper navigations go through `gotoThroughChallenge`: detect the challenge redirect, wait for the headed browser to auto-solve it (cookie persists on the shared context), verify we actually landed on the requested page, retry with backoff, and dump the challenge page's title/body on timeout so a future failure tells us what it showed.
- Adds `scripts/debugChallenge.mjs` + a manual `scrape-debug` workflow: drives the exact scraper browser stack against three 2kratings pages with **no secrets and no Convex writes** — the safe way to test runner-IP behavior. Next step after merge is dispatching it to learn whether the challenge auto-solves from a runner.
- Reconcile safety is untouched: partial/errored scrapes still skip pruning.

## Verified

- Probe passes clean from a residential IP.
- Real one-team scrape against the **dev** deployment: 18 Hawks players parsed off the new **NBA 2K27** markup, zero errors (also proves selectors survived the season flip).

## Heads up discovered en route

2kratings has flipped to **NBA 2K27**. The scraper's default `gameVersion` is still `2K26`, and the UI copy says 2K26 — season-bump follow-up coming separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)