### PR TITLE
chore: season bump to NBA 2K27 via single shared constant

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ import { KeyDialog } from "@/components/chrome/key-dialog";
 import { getRatingClasses, getRatingTier, getAttributeColor } from "@/lib/rating-colors";
 import { getTeamAbbreviation } from "@/lib/team-abbr";
 import { API_KEY_STORAGE_KEY } from "@/lib/constants";
+import { CURRENT_GAME_VERSION } from "@/convex/gameVersion";
 import { cn } from "@/lib/utils";
 
 const RISE_IN =
@@ -172,7 +173,7 @@ export default function Home() {
         <div className="mx-auto grid max-w-[1360px] grid-cols-[repeat(auto-fit,minmax(min(100%,460px),1fr))] items-start gap-[clamp(32px,5vw,72px)] px-[clamp(20px,4vw,48px)] pt-[clamp(32px,5vw,60px)] pb-[72px]">
           <div className="pt-5">
             <div className={cn(MONO_LABEL, "mb-6", RISE_IN)}>
-              FREE REST API — NBA 2K26 RATINGS
+              FREE REST API — NBA {CURRENT_GAME_VERSION} RATINGS
             </div>
             <h1
               className={cn(
@@ -248,7 +249,7 @@ export default function Home() {
           >
             <div className="flex items-center justify-between border-b border-[#efece4] px-5 py-3.5">
               <span className="font-plex text-[11px] tracking-[0.12em] text-[#8a8577]">
-                TOP OVERALL — 2K26 · WEEK {weekOfYear(new Date())}
+                TOP OVERALL — {CURRENT_GAME_VERSION} · WEEK {weekOfYear(new Date())}
               </span>
               <span className="font-plex text-[11px] text-[#b5b0a1]">LIVE</span>
             </div>

--- a/convex/badges.ts
+++ b/convex/badges.ts
@@ -5,6 +5,7 @@
 
 import { mutation, query, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
+import { CURRENT_GAME_VERSION } from "./gameVersion";
 import { Id } from "./_generated/dataModel";
 
 /**
@@ -381,7 +382,7 @@ export const syncBadgesFromPlayers = internalMutation({
           name: badge.name,
           slug,
           category: badge.category,
-          gameVersion: "2K26",
+          gameVersion: CURRENT_GAME_VERSION,
           lastUpdated: now,
           createdAt: now,
         });

--- a/convex/gameVersion.js
+++ b/convex/gameVersion.js
@@ -1,0 +1,8 @@
+/**
+ * The NBA 2K edition currently being scraped from 2kratings.com.
+ * Lives in convex/ so Convex functions, the plain-Node scraper scripts, and
+ * app code all share one value — bump it here (and only here) each season.
+ * Kept as .js (with a .d.ts twin) because scripts/runScraper.js imports it
+ * directly under Node with no TypeScript loader.
+ */
+export const CURRENT_GAME_VERSION = "2K27";

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -12,6 +12,7 @@ import { HonoWithConvex, HttpRouterWithHono } from "convex-helpers/server/hono";
 import { ActionCtx } from "./_generated/server";
 import { api } from "./_generated/api";
 import { Id } from "./_generated/dataModel";
+import { CURRENT_GAME_VERSION } from "./gameVersion";
 import {
   detectUnknownParams,
   formatUnknownParamsError,
@@ -1188,7 +1189,7 @@ app.get("/api/players/:id/versions",
         playerId,
         name: player.name,
         slug: player.slug,
-        currentVersion: player.gameVersion || "2K26",
+        currentVersion: player.gameVersion || CURRENT_GAME_VERSION,
         currentOverall: player.overall,
         ratingHistory: player.ratingHistory || [],
       }));

--- a/convex/playerHistory.ts
+++ b/convex/playerHistory.ts
@@ -5,6 +5,7 @@
 
 import { mutation, query, internalMutation, MutationCtx } from "./_generated/server";
 import { v } from "convex/values";
+import { CURRENT_GAME_VERSION } from "./gameVersion";
 import { Id } from "./_generated/dataModel";
 
 // Badge tier ranking for comparison
@@ -142,7 +143,7 @@ async function upsertWithHistoryHelper(
 ) {
   const { scrapeJobId, ...playerData } = args;
   const now = new Date().toISOString();
-  const gameVersion = args.gameVersion || "2K26";
+  const gameVersion = args.gameVersion || CURRENT_GAME_VERSION;
 
   // Check if player exists by slug, teamType, and team
   const existing = await ctx.db
@@ -454,7 +455,7 @@ export const createWeeklySnapshots = internalMutation({
         await ctx.db.insert("playerSnapshots", {
           playerId: player._id,
           snapshotDate,
-          gameVersion: player.gameVersion || "2K26",
+          gameVersion: player.gameVersion || CURRENT_GAME_VERSION,
           overall: player.overall,
           attributes: player.attributes,
           badges: player.badges,
@@ -570,7 +571,7 @@ export const migrateExistingPlayersToHistory = internalMutation({
         await ctx.db.insert("playerRatingHistory", {
           playerId: player._id,
           scrapedAt: player.createdAt || now,
-          gameVersion: player.gameVersion || "2K26",
+          gameVersion: player.gameVersion || CURRENT_GAME_VERSION,
           newOverall: player.overall,
           changeType: "initial",
           fullAttributes: player.attributes,
@@ -582,7 +583,7 @@ export const migrateExistingPlayersToHistory = internalMutation({
         await ctx.db.insert("playerSnapshots", {
           playerId: player._id,
           snapshotDate: now.split("T")[0],
-          gameVersion: player.gameVersion || "2K26",
+          gameVersion: player.gameVersion || CURRENT_GAME_VERSION,
           overall: player.overall,
           attributes: player.attributes,
           badges: player.badges,

--- a/scripts/runScraper.js
+++ b/scripts/runScraper.js
@@ -5,6 +5,7 @@
 
 import { ConvexHttpClient } from "convex/browser";
 import { api } from "../convex/_generated/api.js";
+import { CURRENT_GAME_VERSION } from "../convex/gameVersion.js";
 import { scrapeTeamLinks, scrapeTeamRoster } from '../scraper/teamScraper.js';
 import { scrapePlayerDetails } from '../scraper/playerScraper.js';
 import { initBrowser, createPage } from '../scraper/utils.js';
@@ -22,7 +23,7 @@ async function runScraper(options = {}) {
     teamType = 'curr',
     teams = null,
     jobId = `scrape_${teamType}_${Date.now()}`,
-    gameVersion = '2K26',
+    gameVersion = CURRENT_GAME_VERSION,
   } = options;
 
   if (!ADMIN_API_KEY) {


### PR DESCRIPTION
2kratings has moved to NBA 2K27 (discovered while fixing the scrape pipeline in #29). This makes the game version a single shared constant — `convex/gameVersion.js` (+ `.d.ts` twin, since the plain-Node scraper imports it at runtime) — used by the scraper default, the Convex fallbacks (playerHistory, badges, http), and the landing hero/leaderboard copy. Next season flip is a one-line change.

Verified: codegen/tsc/build clean, Node runtime import works, one-team dev scrape is idempotent under the new version tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)