### PR TITLE
fix: commit gameVersion.d.ts (convex codegen needs it; was gitignored)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ build/
 .convex/
 convex/_generated/
 convex/*.d.ts
+!convex/gameVersion.d.ts
 convex/*.d.ts.map
 PRD.md
 

--- a/convex/gameVersion.d.ts
+++ b/convex/gameVersion.d.ts
@@ -1,0 +1,1 @@
+export declare const CURRENT_GAME_VERSION: string;


### PR DESCRIPTION
The dispatched scrape run failed in the "Generate Convex client" step: codegen's typecheck raises TS7016 on the untyped `gameVersion.js` import. The `.d.ts` existed locally but `convex/*.d.ts` is gitignored, so CI never received it — a local/CI divergence my pre-merge check missed because Next's tsconfig (allowJs) is laxer than codegen's. Adds the declaration with a gitignore exception; codegen + tsc verified clean with the tracked file only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)