### PR TITLE
feat: history comes from 2kratings — game-to-game + in-season movement

### DIFF
--- a/app/players/[slug]/page.tsx
+++ b/app/players/[slug]/page.tsx
@@ -14,6 +14,7 @@ import { getTeamAbbreviation, formatTeamNickname } from "@/lib/team-abbr";
 import { ATTRIBUTE_CATEGORIES } from "@/convex/attributeCategories";
 import { getAttributeDisplayName } from "@/lib/attribute-normalizer";
 import { depthOrder } from "@/lib/depth-chart";
+import { CURRENT_GAME_VERSION } from "@/convex/gameVersion";
 import { API_KEY_STORAGE_KEY } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
@@ -82,6 +83,18 @@ function shortPlayerLabel(name: string) {
 
 function pctColor(pct: number) {
   return pct >= 85 ? "#0a7f3f" : pct >= 50 ? "#9a6700" : "#c03a2b";
+}
+
+/** "NBA 2K27 Launch Rating" → "LAUNCH", "Nov. 5, 2026" → "NOV 5", playoff rounds compressed. */
+function shortMilestone(label: string): string {
+  if (/launch/i.test(label)) return "LAUNCH";
+  if (/all-star/i.test(label)) return "ALL-STAR";
+  if (/playoffs rd 1/i.test(label)) return "PLAYOFFS";
+  if (/semifinals/i.test(label)) return "SEMIS";
+  if (/conference finals/i.test(label)) return "CONF F";
+  if (/finals/i.test(label)) return "FINALS";
+  const m = label.match(/^([A-Za-z]{3})\.?\s+(\d{1,2})/);
+  return m ? `${m[1].toUpperCase()} ${m[2]}` : label.toUpperCase().slice(0, 8);
 }
 
 function ordinal(n: number) {
@@ -174,24 +187,31 @@ function PlayerDossier() {
     };
   }, [dossier]);
 
-  // History chart geometry
+  // History chart: in-season movement when 2kratings has charted it
+  // (2+ milestones), otherwise their game-to-game overalls.
   const historyChart = useMemo(() => {
-    if (!dossier || dossier.history.length < 2) return null;
-    const values = dossier.history.map((h) => h.overall);
+    if (!dossier) return null;
+    const movement = dossier.seasonMovement ?? [];
+    const useMovement = movement.length >= 2;
+    const source = useMovement
+      ? movement.map((m) => ({ label: shortMilestone(m.label), overall: m.overall }))
+      : dossier.history.map((h) => ({ label: h.gameVersion, overall: h.overall }));
+    if (source.length < 2) return null;
+    const values = source.map((h) => h.overall);
     const min = Math.min(...values) - 0.5;
     const max = Math.max(...values) + 0.5;
     const sx = (i: number) => 24 + (i / (values.length - 1)) * 372;
     const sy = (v: number) => 130 - ((v - min) / (max - min)) * 105;
     const cutoff = TIER_CUTOFFS.find((c) => c > min && c <= max + 0.5) ?? null;
-    const labelIdx = [0, Math.floor((values.length - 1) / 2), values.length - 1];
+    // At most 4 tick labels so milestone names never collide
+    const tickIdx = [...new Set([0, Math.floor((source.length - 1) / 3), Math.floor(((source.length - 1) * 2) / 3), source.length - 1])];
     return {
+      mode: useMovement ? ("season" as const) : ("games" as const),
+      count: source.length,
       line: values.map((v, i) => `${sx(i).toFixed(1)},${sy(v).toFixed(1)}`).join(" "),
       dots: values.map((v, i) => ({ x: sx(i), y: sy(v) })),
       band: cutoff !== null ? { y: sy(cutoff), label: `${cutoff} — ${getRatingTier(cutoff).toUpperCase()}` } : null,
-      ticks: [...new Set(labelIdx)].map((i) => ({
-        x: sx(i),
-        label: dossier.history[i].date.slice(5).replace("-", "/"),
-      })),
+      ticks: tickIdx.map((i) => ({ x: sx(i), label: source[i].label })),
       delta: values[values.length - 1] - values[0],
     };
   }, [dossier]);
@@ -541,7 +561,11 @@ function PlayerDossier() {
 
           {/* Rating history */}
           <div className="rounded-[14px] border border-[#e5e2da] bg-white px-[18px] py-3.5">
-            <div className={cn(CARD_LABEL, "mb-1.5")}>OVERALL — WEEKLY SCRAPES</div>
+            <div className={cn(CARD_LABEL, "mb-1.5")}>
+              {historyChart?.mode === "season"
+                ? `OVERALL — THE ${CURRENT_GAME_VERSION} SEASON`
+                : "OVERALL — GAME TO GAME"}
+            </div>
             {historyChart ? (
               <>
                 <svg viewBox="0 0 396 150" className="block h-auto w-full overflow-visible">
@@ -592,13 +616,16 @@ function PlayerDossier() {
                 </svg>
                 <div className="mt-1.5 font-plex text-[8px] text-[#b5b0a1]">
                   {historyChart.delta >= 0 ? "+" : ""}
-                  {historyChart.delta} OVER {dossier!.history.length} SNAPSHOTS · GET
-                  /api/players/:id/history
+                  {historyChart.delta}{" "}
+                  {historyChart.mode === "season"
+                    ? `ACROSS ${historyChart.count} MILESTONES THIS SEASON`
+                    : `ACROSS ${historyChart.count} GAMES`}{" "}
+                  · GET /api/players/slug/{slug}
                 </div>
               </>
             ) : (
               <div className="flex h-[150px] items-center justify-center font-plex text-[9px] text-[#b5b0a1]">
-                {dossier ? "HISTORY ACCRUES WEEKLY — NOT ENOUGH SNAPSHOTS YET" : "…"}
+                {dossier ? "ONE GAME OF DATA — HISTORY BUILDS EACH 2K RELEASE" : "…"}
               </div>
             )}
           </div>

--- a/convex/dossier.ts
+++ b/convex/dossier.ts
@@ -160,15 +160,14 @@ export const getDossier = query({
         playerImage: p.playerImage ?? null,
       }));
 
-    // Weekly rating history from snapshots
-    const snaps = await ctx.db
-      .query("playerSnapshots")
-      .withIndex("by_playerId", (q) => q.eq("playerId", player._id))
-      .collect();
-    const history = snaps
-      .sort((a, b) => a.snapshotDate.localeCompare(b.snapshotDate))
-      .map((s) => ({ date: s.snapshotDate, overall: s.overall }))
-      .slice(-20);
+    // In-season movement (milestones filled in over the season)
+    const seasonMovement = player.seasonMovement ?? [];
+
+    // Game-to-game rating history, exactly as 2kratings tracks it
+    // (scraped onto the player doc; oldest game first for charting).
+    const history = [...(player.ratingHistory ?? [])]
+      .sort((a, b) => a.gameVersion.localeCompare(b.gameVersion))
+      .map((h) => ({ gameVersion: h.gameVersion, overall: h.overall }));
 
     // Named badges by tier
     const badgeLinks = await ctx.db
@@ -216,6 +215,7 @@ export const getDossier = query({
       overallPct,
       similar,
       history,
+      seasonMovement,
       badges,
     };
   },

--- a/convex/playerHistory.ts
+++ b/convex/playerHistory.ts
@@ -135,6 +135,7 @@ async function upsertWithHistoryHelper(
     badges?: any;
     hotZones?: any;
     ratingHistory?: any[];
+    seasonMovement?: { label: string; overall: number }[];
     gameVersion?: string;
     scrapeJobId?: string;
     lastUpdated: string;
@@ -256,6 +257,9 @@ export const adminUpsertPlayerWithHistory = mutation({
     badges: v.optional(v.any()),
     hotZones: v.optional(v.any()),
     ratingHistory: v.optional(v.array(v.any())),
+    seasonMovement: v.optional(
+      v.array(v.object({ label: v.string(), overall: v.number() }))
+    ),
     gameVersion: v.optional(v.string()),
     scrapeJobId: v.optional(v.string()),
     lastUpdated: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -83,6 +83,12 @@ export default defineSchema({
     ),
 
     // Cross-version historical ratings (from 2kratings.com)
+    // In-season rating movement as 2kratings charts it: fixed milestones
+    // (launch, biweekly dates, All-Star, playoff rounds) filled in over the
+    // season. Only milestones with a rating are stored.
+    seasonMovement: v.optional(
+      v.array(v.object({ label: v.string(), overall: v.number() }))
+    ),
     ratingHistory: v.optional(
       v.array(
         v.object({

--- a/lib/llms-docs.ts
+++ b/lib/llms-docs.ts
@@ -123,6 +123,11 @@ One player, full detail (all attributes, badges, hot zones). Optional
 Name search (partial, word-order-agnostic). Params: \`q\` (required),
 \`teamType\`, \`limit\` (max 50, default 50).
 
+Player documents also carry two history fields straight from 2kratings:
+\`ratingHistory\` (game-to-game overalls: \`[{ gameVersion, overall, delta }]\`)
+and \`seasonMovement\` (in-season milestones for the current game:
+\`[{ label, overall }]\`, filled in as the season progresses).
+
 ## GET /api/players/{id}/history
 
 Weekly rating snapshots for a player. Params: \`gameVersion\`, \`limit\`.

--- a/scraper/playerScraper.js
+++ b/scraper/playerScraper.js
@@ -400,8 +400,13 @@ export async function scrapePlayerDetails(page, basicPlayer) {
         .find((t) => t.includes('chartjs-dashboard-line-player'));
       if (movementScript) {
         try {
-          const labelsMatch = movementScript.match(/labels:\s*(\[[^\]]*\])/);
-          const dataMatch = movementScript.match(/data:\s*(\[[^\]]*\])/);
+          // Anchor past the canvas id so another chart's config in the same
+          // script tag can never be mistaken for the movement chart's.
+          const afterMarker = movementScript.slice(
+            movementScript.indexOf('chartjs-dashboard-line-player')
+          );
+          const labelsMatch = afterMarker.match(/labels:\s*(\[[^\]]*\])/);
+          const dataMatch = afterMarker.match(/data:\s*(\[[^\]]*\])/);
           if (labelsMatch && dataMatch) {
             // Labels are quoted strings; the data array is JS with elisions
             // ("[ 89, , , ]") and trailing commas, so token-parse rather

--- a/scraper/playerScraper.js
+++ b/scraper/playerScraper.js
@@ -389,6 +389,45 @@ export async function scrapePlayerDetails(page, basicPlayer) {
         details.ratingHistory[i].delta = details.ratingHistory[i].overall - details.ratingHistory[i + 1].overall;
       }
 
+      // ========================================
+      // Extract In-Season Rating Movement
+      // ========================================
+      // 2kratings renders "…Rating Season Movement" as a Chart.js line chart
+      // whose config lives in an inline script: labels are fixed season
+      // milestones, data fills in as the season progresses (null = future).
+      const movementScript = Array.from(document.querySelectorAll('script:not([src])'))
+        .map((el) => el.textContent || '')
+        .find((t) => t.includes('chartjs-dashboard-line-player'));
+      if (movementScript) {
+        try {
+          const labelsMatch = movementScript.match(/labels:\s*(\[[^\]]*\])/);
+          const dataMatch = movementScript.match(/data:\s*(\[[^\]]*\])/);
+          if (labelsMatch && dataMatch) {
+            // Labels are quoted strings; the data array is JS with elisions
+            // ("[ 89, , , ]") and trailing commas, so token-parse rather
+            // than JSON.parse.
+            const labels = (labelsMatch[1].match(/"([^"]*)"|'([^']*)'/g) || []).map((q) =>
+              q.slice(1, -1)
+            );
+            const values = dataMatch[1]
+              .slice(1, -1)
+              .split(',')
+              .map((tok) => {
+                const n = Number(tok.trim());
+                return tok.trim() !== '' && Number.isFinite(n) ? n : null;
+              });
+            const movement = labels
+              .map((label, i) => ({ label: String(label), overall: values[i] }))
+              .filter((m) => typeof m.overall === 'number');
+            if (movement.length > 0) {
+              details.seasonMovement = movement;
+            }
+          }
+        } catch {
+          // Chart markup changed — skip quietly; the field is best-effort.
+        }
+      }
+
       return details;
     });
 
@@ -406,6 +445,7 @@ export async function scrapePlayerDetails(page, basicPlayer) {
       badges: playerDetails.badges,
       hotZones: playerDetails.hotZones,
       ratingHistory: playerDetails.ratingHistory,
+      seasonMovement: playerDetails.seasonMovement,
       lastUpdated: new Date().toISOString()
     };
 


### PR DESCRIPTION
Ruling: 2kratings is the source of truth for everything, including history. They track two kinds — game-to-game overalls (already scraped as `ratingHistory`) and the "Rating Season Movement" chart on each player page (fixed milestones: launch, biweekly dates, All-Star, playoff rounds, filled in over the season).

- The scraper now extracts season movement from the inline Chart.js config (the data array uses JS elisions like `[ 89, , , ]`, so it's token-parsed) into a new `players.seasonMovement` field, flowing through the existing upsert (which patches even on "no change", so milestones update every scrape).
- The dossier history card now charts 2kratings data: the current season once it has 2+ milestones, otherwise game-to-game across 2K editions (Jalen Johnson: +15 across 6 games, 2K22→2K27). Our weekly `playerSnapshots` are no longer read by the dossier — the snapshot cron and `/history` endpoint remain for API consumers, removable later if wanted.
- Both fields documented in llms-full.txt.

Prod note: `ratingHistory` is already fresh from today's scrape; `seasonMovement` will populate on the next scrape — tomorrow's scheduled Saturday run covers it.

Verified on dev: parse lands (`[{ "label": "NBA 2K27 Launch Rating", "overall": 89 }]`), chart renders with tier band and correct footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)