### PR TITLE
Fix Vercel preview builds

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build"
+}


### PR DESCRIPTION
## Summary
- override the stale project-wide Convex deploy build command
- run the ordinary application build in every Vercel environment
- keep production Convex deployment in the existing GitHub Actions workflow

## Verification
- `npm run build`
- real Vercel preview reached Ready: https://nba2kapi-9y7rel7mz-wilson-overfields-projects.vercel.app

This fixes preview deployments failing because Vercel tried to use the production-only `CONVEX_DEPLOY_KEY`.
