### PR TITLE
Make the explorer and lineup lab data-driven

### DIFF
--- a/app/lineups/page.tsx
+++ b/app/lineups/page.tsx
@@ -14,7 +14,7 @@ import {
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
-import { Search } from "lucide-react";
+import { Search, SlidersHorizontal, UsersRound, X } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "@/convex/_generated/api";
 import { TopNav } from "@/components/chrome/top-nav";
@@ -122,6 +122,7 @@ function CourtSlot({
   index,
   spot,
   player,
+  compareMode,
   pulsing,
   onRemove,
 }: {
@@ -129,10 +130,11 @@ function CourtSlot({
   index: number;
   spot: { pos: string; x: number; y: number };
   player: PoolPlayer | null;
+  compareMode: boolean;
   pulsing: boolean;
   onRemove: () => void;
 }) {
-  const x = side === "yours" ? spot.x : 100 - spot.x;
+  const x = compareMode ? (side === "yours" ? spot.x : 100 - spot.x) : spot.x + 25;
   const y = (spot.y / 56) * 100;
   const { setNodeRef, isOver } = useDroppable({ id: `slot:${side}:${index}` });
   const drag = useDraggable({
@@ -243,6 +245,11 @@ function Whiteboard() {
   const [q, setQ] = useState("");
   const [posF, setPosF] = useState("ALL");
   const [sortF, setSortF] = useState<"ovr" | "az">("ovr");
+  const [eraF, setEraF] = useState<"all" | TeamType>("all");
+  const [minOvr, setMinOvr] = useState(0);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerSide, setPickerSide] = useState<Side>("yours");
+  const [matchupMode, setMatchupMode] = useState(false);
   const [dragging, setDragging] = useState<PoolPlayer | null>(null);
   // Browsers synthesize a click after pointerup, so a completed drag would
   // also fire the tap handlers (remove / tap-place). Swallow clicks that
@@ -286,7 +293,10 @@ function Whiteboard() {
       return slots;
     };
     if (state.lineup1.length) setYours(fill(state.lineup1));
-    if (state.lineup2?.length) setOpps(fill(state.lineup2));
+    if (state.lineup2?.length) {
+      setOpps(fill(state.lineup2));
+      setMatchupMode(true);
+    }
     setHydrated(true);
   }, [players, hydrated, searchParams]);
 
@@ -299,14 +309,14 @@ function Whiteboard() {
         .map((p) => ({ slug: p.slug, teamType: p.teamType, team: p.team }));
     const params = lineupToURLParams({
       lineup1: toEntries(yours),
-      lineup2: toEntries(opps),
+      lineup2: matchupMode ? toEntries(opps) : [],
       filterTeamType: "curr",
     });
     const next = params.toString();
     if (next !== searchParams.toString()) {
       router.replace(next ? `/lineups?${next}` : "/lineups", { scroll: false });
     }
-  }, [yours, opps, hydrated, router, searchParams]);
+  }, [yours, opps, matchupMode, hydrated, router, searchParams]);
 
   const yoursFilled = yours.filter((p): p is PoolPlayer => p !== null);
   const oppsFilled = opps.filter((p): p is PoolPlayer => p !== null);
@@ -329,11 +339,13 @@ function Whiteboard() {
       .filter(
         (p) =>
           (posF === "ALL" || p.positions.includes(posF)) &&
+          (eraF === "all" || p.teamType === eraF) &&
+          p.overall >= minOvr &&
           (!query || p.name.toLowerCase().includes(query))
       )
       .sort((a, b) => (sortF === "ovr" ? b.overall - a.overall : a.name.localeCompare(b.name)))
       .slice(0, POOL_LIMIT);
-  }, [players, q, posF, sortF]);
+  }, [players, q, posF, eraF, minOvr, sortF]);
 
   const place = (side: Side, index: number, p: PoolPlayer) => {
     const setter = side === "yours" ? setYours : setOpps;
@@ -353,12 +365,22 @@ function Whiteboard() {
     });
   };
 
-  // Tap fallback: your matching slot first, then theirs
+  // The picker always targets the lineup the user explicitly opened it for.
   const tapPlace = (p: PoolPlayer) => {
     const idx = primarySlot(p);
-    if (!yours[idx]) return place("yours", idx, p);
-    if (!opps[idx]) return place("opps", idx, p);
-    toast(`Both ${POSITIONS[idx]} spots are taken — drag onto a slot to replace`);
+    const slots = pickerSide === "yours" ? yours : opps;
+    if (!slots[idx]) {
+      place(pickerSide, idx, p);
+      setPickerOpen(false);
+      return;
+    }
+    const open = slots.findIndex((slot) => slot === null);
+    if (open >= 0) {
+      place(pickerSide, open, p);
+      setPickerOpen(false);
+      return;
+    }
+    toast(`${pickerSide === "yours" ? "Your" : "Opponent"} lineup is full — remove or replace a player first`);
   };
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
@@ -437,8 +459,8 @@ function Whiteboard() {
   const reads = useMemo(() => {
     if (yoursFilled.length === 0) {
       return [
-        { tag: "START", c: "#8a8577", t: "Tap or drag anyone from the pool to seat your five — mixing eras is the whole point." },
-        { tag: "TIP", c: "#8a8577", t: "Filter the pool by position to fill a specific spot; the tape below builds as you go." },
+        { tag: "START", c: "#8a8577", t: "Open the player picker and seat your five — mixing eras is the whole point." },
+        { tag: "TIP", c: "#8a8577", t: "Use position, era, and rating filters to find the right fit; the analysis builds as you go." },
       ];
     }
     if (hasOpp) {
@@ -526,15 +548,45 @@ function Whiteboard() {
       <TopNav hasApiKey={hasApiKey} width="wide" />
 
       <div className="mx-auto max-w-[1440px] px-[clamp(20px,4vw,48px)] pt-2 pb-12">
-        <div className="flex justify-end animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none">
-          <div className="flex items-center gap-2.5">
-            {hasOpp && (
+        <div className="flex flex-wrap items-center justify-between gap-3 animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none">
+          <div>
+            <div className="font-plex text-[9px] tracking-[0.12em] text-[#8a8577]">LINEUP LAB</div>
+            <h1 className="mt-1 mb-0 font-display text-[clamp(24px,3vw,36px)] font-bold tracking-[-0.03em]">
+              {matchupMode ? "Build the matchup" : "Build your five"}
+            </h1>
+          </div>
+          <div className="flex flex-wrap items-center justify-end gap-2.5">
+            <button
+              type="button"
+              onClick={() => { setPickerSide("yours"); setPickerOpen(true); }}
+              className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-[#1a1918] bg-white px-3.5 py-[7px] text-[11.5px] font-semibold transition-[background,transform] hover:bg-[#f1efe8] active:scale-[0.97]"
+            >
+              <Search className="h-3.5 w-3.5" /> Add player
+            </button>
+            {!matchupMode ? (
               <button
                 type="button"
-                onClick={() => setOpps([null, null, null, null, null])}
+                onClick={() => setMatchupMode(true)}
+                className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-[#e5e2da] bg-white px-3.5 py-[7px] text-[11.5px] font-semibold transition-[border-color,transform] hover:border-[#1a1918] active:scale-[0.97]"
+              >
+                <UsersRound className="h-3.5 w-3.5" /> Add opponent
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() => { setPickerSide("opps"); setPickerOpen(true); }}
+                className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-[#e5e2da] bg-white px-3.5 py-[7px] text-[11.5px] font-semibold transition-[border-color,transform] hover:border-[#1a1918] active:scale-[0.97]"
+              >
+                <Search className="h-3.5 w-3.5" /> Add opponent player
+              </button>
+            )}
+            {matchupMode && (
+              <button
+                type="button"
+                onClick={() => { setOpps([null, null, null, null, null]); setMatchupMode(false); }}
                 className="cursor-pointer rounded-full border border-[#e5e2da] bg-white px-3.5 py-[7px] text-[11.5px] font-semibold text-[#1a1918] transition-[border-color,transform] duration-150 hover:border-[#1a1918] active:scale-[0.97] motion-reduce:transition-none"
               >
-                Clear opponent
+                Single lineup
               </button>
             )}
             {yoursFilled.length > 0 && (
@@ -568,10 +620,10 @@ function Whiteboard() {
             lastDragEndRef.current = Date.now();
           }}
         >
-          <div className="mt-4 grid grid-cols-[repeat(auto-fit,minmax(min(100%,270px),1fr))] items-start gap-3.5">
+          <div className="mt-4 grid items-start gap-3.5">
             {/* Player pool */}
             <div
-              className="overflow-hidden rounded-[14px] border border-[#e5e2da] bg-white animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
+              className="hidden overflow-hidden rounded-[14px] border border-[#e5e2da] bg-white"
               style={{ animationDelay: "60ms" }}
             >
               <div className="border-b border-[#f1efe8] px-4 pt-[11px] pb-3">
@@ -644,18 +696,18 @@ function Whiteboard() {
             </div>
 
             {/* Court + analysis */}
-            <div className="min-w-0 lg:col-span-2" style={{ gridColumn: "span 2" }}>
+            <div className="min-w-0">
               <div
                 className="relative aspect-[16/9.4] overflow-hidden rounded-2xl border border-[#e5e2da] bg-[#f6f4ee] animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
                 style={{ animationDelay: "100ms" }}
               >
                 <svg viewBox="0 0 100 56" preserveAspectRatio="none" className="absolute inset-0 h-full w-full">
-                  <line x1="50" y1="0" x2="50" y2="56" stroke="#d9d4c7" strokeWidth="0.25" />
+                  {matchupMode && <line x1="50" y1="0" x2="50" y2="56" stroke="#d9d4c7" strokeWidth="0.25" />}
                   <circle cx="50" cy="28" r="7" fill="none" stroke="#d9d4c7" strokeWidth="0.25" />
                   <rect x="0" y="18" width="14" height="20" fill="none" stroke="#d9d4c7" strokeWidth="0.25" />
-                  <rect x="86" y="18" width="14" height="20" fill="none" stroke="#d9d4c7" strokeWidth="0.25" />
+                  {matchupMode && <rect x="86" y="18" width="14" height="20" fill="none" stroke="#d9d4c7" strokeWidth="0.25" />}
                   <path d="M 0 6 Q 30 28 0 50" fill="none" stroke="#d9d4c7" strokeWidth="0.25" />
-                  <path d="M 100 6 Q 70 28 100 50" fill="none" stroke="#d9d4c7" strokeWidth="0.25" />
+                  {matchupMode && <path d="M 100 6 Q 70 28 100 50" fill="none" stroke="#d9d4c7" strokeWidth="0.25" />}
                   {guardLines.map((l, i) => (
                     <line
                       key={i}
@@ -670,7 +722,7 @@ function Whiteboard() {
                   ))}
                 </svg>
 
-                <span className="absolute top-2.5 left-3.5 font-plex text-[8.5px] tracking-[0.1em] text-[#b5b0a1]">
+                <span className={cn("absolute top-2.5 font-plex text-[8.5px] tracking-[0.1em] text-[#b5b0a1]", matchupMode ? "left-3.5" : "left-1/2 -translate-x-1/2")}>
                   YOUR FIVE · {yoursFilled.length}/5
                   {yourOvr !== null && (
                     <>
@@ -679,7 +731,7 @@ function Whiteboard() {
                     </>
                   )}
                 </span>
-                <span className="absolute top-2.5 right-3.5 font-plex text-[8.5px] tracking-[0.1em] text-[#b5b0a1]">
+                {matchupMode && <span className="absolute top-2.5 right-3.5 font-plex text-[8.5px] tracking-[0.1em] text-[#b5b0a1]">
                   {hasOpp ? (
                     <>
                       THEIR FIVE · {oppsFilled.length}/5 ·{" "}
@@ -688,7 +740,7 @@ function Whiteboard() {
                   ) : (
                     "OPEN HALF — ADD FROM THE POOL"
                   )}
-                </span>
+                </span>}
 
                 {SPOTS.map((spot, i) => (
                   <CourtSlot
@@ -697,28 +749,28 @@ function Whiteboard() {
                     index={i}
                     spot={spot}
                     player={yours[i]}
+                    compareMode={matchupMode}
                     pulsing={false}
                     onRemove={guardedTap(() => remove("yours", i))}
                   />
                 ))}
-                {SPOTS.map((spot, i) => (
+                {matchupMode && SPOTS.map((spot, i) => (
                   <CourtSlot
                     key={`opps-${spot.pos}`}
                     side="opps"
                     index={i}
                     spot={spot}
                     player={opps[i]}
+                    compareMode={matchupMode}
                     pulsing={hasOpp}
                     onRemove={guardedTap(() => remove("opps", i))}
                   />
                 ))}
 
-                {!hasOpp && (
-                  <div className="absolute top-1/2 right-[6%] max-w-[150px] -translate-y-1/2 text-center font-plex text-[9px] leading-[1.8] tracking-[0.08em] text-[#b5b0a1]">
-                    DROP ANYONE ON THIS HALF
-                    <br />
-                    TO START A MATCHUP
-                  </div>
+                {!matchupMode && yoursFilled.length === 0 && (
+                  <button type="button" onClick={() => { setPickerSide("yours"); setPickerOpen(true); }} className="absolute bottom-[8%] left-1/2 -translate-x-1/2 cursor-pointer rounded-full bg-[#1a1918] px-4 py-2 text-[11px] font-semibold text-white shadow-lg">
+                    Choose your first player
+                  </button>
                 )}
               </div>
 
@@ -827,6 +879,68 @@ function Whiteboard() {
               )}
             </div>
           </div>
+
+          {pickerOpen && (
+            <div
+              className="fixed inset-0 z-50 flex items-end justify-center bg-[#1a1918]/35 p-0 backdrop-blur-[2px] sm:items-center sm:p-6"
+              role="dialog"
+              aria-modal="true"
+              aria-label={`Choose a player for ${pickerSide === "yours" ? "your lineup" : "the opponent"}`}
+              onMouseDown={(e) => { if (e.target === e.currentTarget) setPickerOpen(false); }}
+            >
+              <div className="flex max-h-[88vh] w-full max-w-[760px] flex-col overflow-hidden rounded-t-[22px] border border-[#d9d4c7] bg-[#fffdf8] shadow-[0_30px_80px_-24px_rgba(26,25,24,0.55)] sm:rounded-[22px]">
+                <div className="flex items-start justify-between gap-4 border-b border-[#e5e2da] px-5 py-4">
+                  <div>
+                    <div className="font-plex text-[9px] tracking-[0.12em] text-[#8a8577]">
+                      {pickerSide === "yours" ? "YOUR FIVE" : "OPPONENT"} · PLAYER PICKER
+                    </div>
+                    <h2 className="mt-1 mb-0 font-display text-[24px] font-bold tracking-[-0.025em]">Find the right player</h2>
+                  </div>
+                  <button type="button" onClick={() => setPickerOpen(false)} className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-full border border-[#e5e2da] bg-white hover:border-[#1a1918]" aria-label="Close player picker">
+                    <X className="h-4 w-4" />
+                  </button>
+                </div>
+
+                <div className="border-b border-[#e5e2da] bg-white px-5 py-4">
+                  <div className="flex items-center gap-2 rounded-full border border-[#d9d4c7] bg-[#faf9f5] px-4 py-3">
+                    <Search className="h-4 w-4 text-[#8a8577]" />
+                    <input autoFocus value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search any player or legend…" className="min-w-0 flex-1 border-0 bg-transparent text-[14px] outline-none placeholder:text-[#b5b0a1]" />
+                    <span className="font-plex text-[8px] text-[#b5b0a1]">{pool.length} SHOWN</span>
+                  </div>
+                  <div className="mt-3 grid gap-3 sm:grid-cols-[1fr_1fr_auto]">
+                    <div>
+                      <div className="mb-1.5 flex items-center gap-1.5 font-plex text-[8px] tracking-[0.08em] text-[#8a8577]"><SlidersHorizontal className="h-3 w-3" /> POSITION</div>
+                      <div className="flex flex-wrap gap-1.5">
+                        {["ALL", ...POSITIONS].map((label) => <button key={label} type="button" onClick={() => setPosF(label)} className={cn("cursor-pointer rounded-full border px-2.5 py-1 font-plex text-[8px] font-bold", posF === label ? "border-[#1a1918] bg-[#1a1918] text-white" : "border-[#e5e2da] bg-[#faf9f5] text-[#8a8577]")}>{label}</button>)}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="mb-1.5 font-plex text-[8px] tracking-[0.08em] text-[#8a8577]">ERA</div>
+                      <div className="flex flex-wrap gap-1.5">
+                        {([['all','ALL'],['curr','CURRENT'],['class','CLASSIC'],['allt','ALL-TIME']] as const).map(([value,label]) => <button key={value} type="button" onClick={() => setEraF(value)} className={cn("cursor-pointer rounded-full border px-2.5 py-1 font-plex text-[8px] font-bold", eraF === value ? "border-[#1a1918] bg-[#1a1918] text-white" : "border-[#e5e2da] bg-[#faf9f5] text-[#8a8577]")}>{label}</button>)}
+                      </div>
+                    </div>
+                    <label className="block min-w-[130px]">
+                      <span className="mb-1.5 block font-plex text-[8px] tracking-[0.08em] text-[#8a8577]">MIN OVR · {minOvr || "ANY"}</span>
+                      <input type="range" min="0" max="95" step="5" value={minOvr} onChange={(e) => setMinOvr(Number(e.target.value))} className="w-full accent-[#1a1918]" />
+                    </label>
+                  </div>
+                  <div className="mt-3 flex items-center justify-between">
+                    <button type="button" onClick={() => { setQ(""); setPosF("ALL"); setEraF("all"); setMinOvr(0); }} className="cursor-pointer border-0 bg-transparent font-plex text-[8px] text-[#8a8577] underline underline-offset-4">CLEAR FILTERS</button>
+                    <button type="button" onClick={() => setSortF((s) => s === "ovr" ? "az" : "ovr")} className="cursor-pointer border-0 bg-transparent font-plex text-[8px] text-[#57534a]">SORT · {sortF === "ovr" ? "OVR ↓" : "A–Z"}</button>
+                  </div>
+                </div>
+
+                <div className="min-h-0 flex-1 overflow-y-auto bg-white">
+                  {players ? pool.map((p) => (
+                    <PoolRow key={`${p.slug}:${p.teamType}:${p.team}`} p={p} placed={placedKeys.has(`${p.slug}:${p.teamType}:${p.team}`)} onTap={guardedTap(() => tapPlace(p))} />
+                  )) : Array.from({ length: 8 }, (_, i) => <div key={i} className="h-12 animate-pulse border-b border-[#faf8f2] bg-[#f1efe8]" />)}
+                  {players && pool.length === 0 && <div className="px-5 py-16 text-center font-plex text-[9px] tracking-[0.08em] text-[#b5b0a1]">NO MATCHES · TRY WIDENING THE FILTERS</div>}
+                </div>
+                <div className="border-t border-[#e5e2da] bg-[#faf9f5] px-5 py-3 font-plex text-[8px] text-[#8a8577]">TAP A PLAYER TO ADD · DUPLICATE 2K VERSIONS STAY SEPARATE BY ERA + TEAM</div>
+              </div>
+            </div>
+          )}
 
           <DragOverlay dropAnimation={null}>
             {dragging && (

--- a/app/lineups/page.tsx
+++ b/app/lineups/page.tsx
@@ -751,7 +751,7 @@ function Whiteboard() {
       <div className="mx-auto max-w-[1440px] px-[clamp(20px,4vw,48px)] pt-2 pb-12">
         <div className="flex flex-wrap items-center justify-between gap-3 animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none">
           <div>
-            <div className="font-plex text-[9px] tracking-[0.12em] text-[#8a8577]">LINEUP LAB</div>
+            <div className="font-plex text-[9px] tracking-[0.12em] text-[#8a8577]">LINEUP BUILDER</div>
             <h1 className="mt-1 mb-0 font-display text-[clamp(24px,3vw,36px)] font-bold tracking-[-0.03em]">
               {matchupMode ? "Build the matchup" : "Build your five"}
             </h1>

--- a/app/lineups/page.tsx
+++ b/app/lineups/page.tsx
@@ -55,6 +55,14 @@ type PoolPlayer = {
   };
 };
 
+type FullPlayerRecord = {
+  slug: string;
+  team: string;
+  teamType: TeamType;
+  attributes?: Record<string, number>;
+  badges?: { list?: { name: string; tier: string }[] };
+};
+
 const POSITIONS = ["PG", "SG", "SF", "PF", "C"] as const;
 
 // Court spot geometry from the design (viewBox 100 x 56), left half; the
@@ -419,6 +427,14 @@ function Whiteboard() {
   };
 
   const players = useQuery(api.players.getPlaygroundPlayers) as PoolPlayer[] | undefined;
+  const selectedSlugs = useMemo(
+    () => [...new Set([...yours, ...opps].filter((p): p is PoolPlayer => p !== null).map((p) => p.slug))],
+    [yours, opps]
+  );
+  const fullSelectedPlayers = useQuery(
+    api.players.getPlayersBySlugs,
+    selectedSlugs.length ? { slugs: selectedSlugs } : "skip"
+  ) as FullPlayerRecord[] | undefined;
 
   useEffect(() => {
     setHasApiKey(!!localStorage.getItem(API_KEY_STORAGE_KEY));
@@ -681,7 +697,24 @@ function Whiteboard() {
       },
     ];
   }, [yoursFilled, oppsFilled, hasOpp, yourOvr, oppOvr]);
-  const lineupReport = useMemo(() => buildLineupReport(yoursFilled), [yoursFilled]);
+  const reportPlayers = useMemo(() => {
+    if (yoursFilled.length === 0) return [];
+    if (!fullSelectedPlayers) return null;
+    return yoursFilled.map((player) => {
+      const full = fullSelectedPlayers.find((candidate) =>
+        candidate.slug === player.slug && candidate.teamType === player.teamType && candidate.team === player.team
+      ) ?? fullSelectedPlayers.find((candidate) => candidate.slug === player.slug && candidate.teamType === player.teamType);
+      return {
+        ...player,
+        attributes: full?.attributes ?? player.attributes ?? {},
+        badges: full?.badges?.list ?? player.badges ?? [],
+      };
+    });
+  }, [yoursFilled, fullSelectedPlayers]);
+  const lineupReport = useMemo(
+    () => reportPlayers ? buildLineupReport(reportPlayers) : null,
+    [reportPlayers]
+  );
 
   const duels = useMemo(
     () =>
@@ -961,7 +994,9 @@ function Whiteboard() {
               {!hasOpp && !lineupReport && (
                 <div className="mt-3 rounded-[14px] border border-[#e5e2da] bg-white px-[18px] py-4">
                   <div className="font-plex text-[8px] tracking-[0.12em] text-[#8a8577]">LINEUP REPORT</div>
-                  <div className="mt-1 text-[12px] text-[#57534a]">Drag in your first player to start the analysis.</div>
+                  <div className="mt-1 text-[12px] text-[#57534a]">
+                    {yoursFilled.length ? "Loading full attributes and badges…" : "Drag in your first player to start the analysis."}
+                  </div>
                 </div>
               )}
 

--- a/app/lineups/page.tsx
+++ b/app/lineups/page.tsx
@@ -528,7 +528,7 @@ function Whiteboard() {
   const reads = useMemo(() => {
     if (yoursFilled.length === 0) {
       return [
-        { tag: "START", c: "#8a8577", t: "Open the player picker and seat your five — mixing eras is the whole point." },
+        { tag: "START", c: "#8a8577", t: "Drag or tap from the player pool to seat your five — mixing eras is the whole point." },
         { tag: "TIP", c: "#8a8577", t: "Use position, era, and rating filters to find the right fit; the analysis builds as you go." },
       ];
     }
@@ -625,13 +625,6 @@ function Whiteboard() {
             </h1>
           </div>
           <div className="flex flex-wrap items-center justify-end gap-2.5">
-            <button
-              type="button"
-              onClick={() => { setPickerSide("yours"); setPickerOpen(true); }}
-              className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-[#1a1918] bg-white px-3.5 py-[7px] text-[11.5px] font-semibold transition-[background,transform] hover:bg-[#f1efe8] active:scale-[0.97]"
-            >
-              <Search className="h-3.5 w-3.5" /> Add player
-            </button>
             {!matchupMode ? (
               <button
                 type="button"
@@ -640,15 +633,7 @@ function Whiteboard() {
               >
                 <UsersRound className="h-3.5 w-3.5" /> Add opponent
               </button>
-            ) : (
-              <button
-                type="button"
-                onClick={() => { setPickerSide("opps"); setPickerOpen(true); }}
-                className="inline-flex cursor-pointer items-center gap-2 rounded-full border border-[#e5e2da] bg-white px-3.5 py-[7px] text-[11.5px] font-semibold transition-[border-color,transform] hover:border-[#1a1918] active:scale-[0.97]"
-              >
-                <Search className="h-3.5 w-3.5" /> Add opponent player
-              </button>
-            )}
+            ) : null}
             {matchupMode && (
               <button
                 type="button"
@@ -689,10 +674,10 @@ function Whiteboard() {
             lastDragEndRef.current = Date.now();
           }}
         >
-          <div className="mt-4 grid items-start gap-3.5">
+          <div className="mt-4 grid items-start gap-3.5 lg:grid-cols-[minmax(260px,0.72fr)_minmax(0,2fr)]">
             {/* Player pool */}
             <div
-              className="hidden overflow-hidden rounded-[14px] border border-[#e5e2da] bg-white"
+              className="overflow-hidden rounded-[14px] border border-[#e5e2da] bg-white animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
               style={{ animationDelay: "60ms" }}
             >
               <div className="border-b border-[#f1efe8] px-4 pt-[11px] pb-3">
@@ -700,13 +685,10 @@ function Whiteboard() {
                   <span className="font-plex text-[9px] tracking-[0.1em] text-[#8a8577]">
                     PLAYER POOL — ANY ERA
                   </span>
-                  <button
-                    type="button"
-                    onClick={() => setSortF((s) => (s === "ovr" ? "az" : "ovr"))}
-                    className="cursor-pointer font-plex text-[8.5px] text-[#57534a] transition-colors duration-150 select-none hover:text-[#1a1918]"
-                  >
-                    SORT: {sortF === "ovr" ? "OVR" : "A–Z"} ⇅
-                  </button>
+                  <div className="flex items-center gap-2">
+                    <button type="button" onClick={() => setSortF((s) => (s === "ovr" ? "az" : "ovr"))} className="cursor-pointer font-plex text-[8.5px] text-[#57534a] hover:text-[#1a1918]">{sortF === "ovr" ? "OVR ↓" : "A–Z"}</button>
+                    <button type="button" onClick={() => setPickerOpen(true)} className="inline-flex cursor-pointer items-center gap-1 rounded-full border border-[#d9d4c7] bg-[#faf9f5] px-2 py-1 font-plex text-[8px] font-bold text-[#57534a] hover:border-[#1a1918]"><SlidersHorizontal className="h-3 w-3" /> FILTER</button>
+                  </div>
                 </div>
                 <div className="mb-[9px] flex items-center gap-2 rounded-full border border-[#e5e2da] bg-[#faf9f5] px-3 py-2">
                   <Search className="h-[13px] w-[13px] text-[#8a8577]" strokeWidth={2} />
@@ -734,9 +716,18 @@ function Whiteboard() {
                     </button>
                   ))}
                 </div>
+                {matchupMode && (
+                  <div className="mt-2.5 flex items-center justify-between border-t border-[#f1efe8] pt-2.5">
+                    <span className="font-plex text-[8px] text-[#8a8577]">TAP TARGET</span>
+                    <div className="flex rounded-full border border-[#e5e2da] bg-[#faf9f5] p-0.5">
+                      <button type="button" onClick={() => setPickerSide("yours")} className={cn("cursor-pointer rounded-full px-2 py-0.5 font-plex text-[7.5px] font-bold", pickerSide === "yours" ? "bg-[#1a1918] text-white" : "text-[#8a8577]")}>YOUR FIVE</button>
+                      <button type="button" onClick={() => setPickerSide("opps")} className={cn("cursor-pointer rounded-full px-2 py-0.5 font-plex text-[7.5px] font-bold", pickerSide === "opps" ? "bg-[#1a1918] text-white" : "text-[#8a8577]")}>THEIRS</button>
+                    </div>
+                  </div>
+                )}
               </div>
 
-              <div className="max-h-[520px] overflow-y-auto">
+              <div className="max-h-[500px] overflow-y-auto">
                 {players
                   ? pool.map((p) => (
                       <PoolRow
@@ -768,14 +759,13 @@ function Whiteboard() {
             <div className="min-w-0">
               <div
                 className={cn(
-                  "relative mx-auto overflow-hidden rounded-2xl border border-[#d9c49a] bg-[#f4e4c3] shadow-[0_22px_55px_-38px_rgba(81,59,29,0.7)] transition-[max-width,aspect-ratio] duration-500 ease-out animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:transition-none motion-reduce:animate-none",
-                  matchupMode ? "aspect-[94/50] w-full max-w-none" : "aspect-[47/50] w-full max-w-[680px]"
+                  "relative mx-auto aspect-[94/50] w-full overflow-hidden rounded-2xl border border-[#d9c49a] bg-[#f4e4c3] shadow-[0_22px_55px_-38px_rgba(81,59,29,0.7)] animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
                 )}
                 style={{ animationDelay: "100ms" }}
               >
-                <CourtDiagram matchupMode={matchupMode} guardLines={guardLines} />
+                <CourtDiagram matchupMode={true} guardLines={matchupMode ? guardLines : []} />
 
-                <span className={cn("absolute top-2.5 font-plex text-[8.5px] tracking-[0.1em] text-[#b5b0a1]", matchupMode ? "left-3.5" : "left-1/2 -translate-x-1/2")}>
+                <span className="absolute top-2.5 left-3.5 font-plex text-[8.5px] tracking-[0.1em] text-[#967d58]">
                   YOUR FIVE · {yoursFilled.length}/5
                   {yourOvr !== null && (
                     <>
@@ -802,7 +792,7 @@ function Whiteboard() {
                     index={i}
                     spot={spot}
                     player={yours[i]}
-                    compareMode={matchupMode}
+                    compareMode={true}
                     pulsing={false}
                     onRemove={guardedTap(() => remove("yours", i))}
                   />
@@ -820,11 +810,6 @@ function Whiteboard() {
                   />
                 ))}
 
-                {!matchupMode && yoursFilled.length === 0 && (
-                  <button type="button" onClick={() => { setPickerSide("yours"); setPickerOpen(true); }} className="absolute bottom-[8%] left-1/2 -translate-x-1/2 cursor-pointer rounded-full bg-[#1a1918] px-4 py-2 text-[11px] font-semibold text-white shadow-lg">
-                    Choose your first player
-                  </button>
-                )}
               </div>
 
               {/* Tape + read */}
@@ -935,18 +920,19 @@ function Whiteboard() {
 
           {pickerOpen && (
             <div
-              className="pointer-events-none fixed inset-0 z-50 flex items-end justify-center bg-[#1a1918]/35 backdrop-blur-[2px] lg:items-stretch lg:justify-end lg:bg-transparent lg:backdrop-blur-none"
+              className="fixed inset-0 z-50 flex items-end justify-center bg-[#1a1918]/35 p-0 backdrop-blur-[2px] sm:items-center sm:p-6"
               role="dialog"
               aria-modal="true"
-              aria-label={`Choose a player for ${pickerSide === "yours" ? "your lineup" : "the opponent"}`}
+              aria-label="Advanced player filters"
+              onMouseDown={(e) => { if (e.target === e.currentTarget) setPickerOpen(false); }}
             >
-              <div className="pointer-events-auto flex max-h-[90vh] w-full flex-col overflow-hidden rounded-t-[22px] border border-[#d9d4c7] bg-[#fffdf8] shadow-[0_30px_80px_-24px_rgba(26,25,24,0.55)] lg:my-3 lg:mr-3 lg:max-h-none lg:w-[440px] lg:rounded-[22px]">
+              <div className="flex max-h-[90vh] w-full max-w-[640px] flex-col overflow-hidden rounded-t-[22px] border border-[#d9d4c7] bg-[#fffdf8] shadow-[0_30px_80px_-24px_rgba(26,25,24,0.55)] sm:rounded-[22px]">
                 <div className="flex items-start justify-between gap-4 border-b border-[#e5e2da] px-5 py-4">
                   <div>
                     <div className="font-plex text-[9px] tracking-[0.12em] text-[#8a8577]">
-                      {pickerSide === "yours" ? "YOUR FIVE" : "OPPONENT"} · PLAYER PICKER
+                      PLAYER POOL · ADVANCED FILTERS
                     </div>
-                    <h2 className="mt-1 mb-0 font-display text-[24px] font-bold tracking-[-0.025em]">Find the right player</h2>
+                    <h2 className="mt-1 mb-0 font-display text-[24px] font-bold tracking-[-0.025em]">Narrow the pool</h2>
                   </div>
                   <button type="button" onClick={() => setPickerOpen(false)} className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-full border border-[#e5e2da] bg-white hover:border-[#1a1918]" aria-label="Close player picker">
                     <X className="h-4 w-4" />
@@ -954,12 +940,7 @@ function Whiteboard() {
                 </div>
 
                 <div className="border-b border-[#e5e2da] bg-white px-5 py-4">
-                  <div className="flex items-center gap-2 rounded-full border border-[#d9d4c7] bg-[#faf9f5] px-4 py-3">
-                    <Search className="h-4 w-4 text-[#8a8577]" />
-                    <input autoFocus value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search any player or legend…" className="min-w-0 flex-1 border-0 bg-transparent text-[14px] outline-none placeholder:text-[#b5b0a1]" />
-                    <span className="font-plex text-[8px] text-[#b5b0a1]">{pool.length} SHOWN</span>
-                  </div>
-                  <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                  <div className="grid gap-3 sm:grid-cols-2">
                     <div>
                       <div className="mb-1.5 flex items-center gap-1.5 font-plex text-[8px] tracking-[0.08em] text-[#8a8577]"><SlidersHorizontal className="h-3 w-3" /> POSITION</div>
                       <div className="flex flex-wrap gap-1.5">
@@ -1015,17 +996,12 @@ function Whiteboard() {
                   </div>
                   <div className="mt-3 flex items-center justify-between">
                     <button type="button" onClick={() => { setQ(""); setPosF("ALL"); setEraF("all"); setMinOvr(0); setMaxOvr(99); setRatingTierF("all"); setAttributeF("all"); setAttributeMin(80); setBadgeF("all"); setBadgeTierF("all"); }} className="cursor-pointer border-0 bg-transparent font-plex text-[8px] text-[#8a8577] underline underline-offset-4">CLEAR FILTERS</button>
-                    <button type="button" onClick={() => setSortF((s) => s === "ovr" ? "az" : "ovr")} className="cursor-pointer border-0 bg-transparent font-plex text-[8px] text-[#57534a]">SORT · {sortF === "ovr" ? "OVR ↓" : "A–Z"}</button>
+                    <div className="flex items-center gap-3">
+                      <span className="font-plex text-[8px] text-[#8a8577]">{pool.length} MATCH</span>
+                      <button type="button" onClick={() => setPickerOpen(false)} className="cursor-pointer rounded-full bg-[#1a1918] px-4 py-2 text-[10px] font-semibold text-white">SHOW PLAYERS</button>
+                    </div>
                   </div>
                 </div>
-
-                <div className="min-h-0 flex-1 overflow-y-auto bg-white">
-                  {players ? pool.map((p) => (
-                    <PoolRow key={`${p.slug}:${p.teamType}:${p.team}`} p={p} placed={placedKeys.has(`${p.slug}:${p.teamType}:${p.team}`)} onTap={guardedTap(() => tapPlace(p))} />
-                  )) : Array.from({ length: 8 }, (_, i) => <div key={i} className="h-12 animate-pulse border-b border-[#faf8f2] bg-[#f1efe8]" />)}
-                  {players && pool.length === 0 && <div className="px-5 py-16 text-center font-plex text-[9px] tracking-[0.08em] text-[#b5b0a1]">NO MATCHES · TRY WIDENING THE FILTERS</div>}
-                </div>
-                <div className="border-t border-[#e5e2da] bg-[#faf9f5] px-5 py-3 font-plex text-[8px] text-[#8a8577]">DRAG ONTO A COURT SLOT · TAP TO AUTO-PLACE · VERSIONS STAY SEPARATE BY ERA + TEAM</div>
               </div>
             </div>
           )}

--- a/app/lineups/page.tsx
+++ b/app/lineups/page.tsx
@@ -21,6 +21,9 @@ import { TopNav } from "@/components/chrome/top-nav";
 import { FooterStrip } from "@/components/chrome/footer-strip";
 import { Headshot } from "@/components/ui/headshot";
 import { getRatingClasses } from "@/lib/rating-colors";
+import { getRatingTier } from "@/lib/rating-colors";
+import { getAttributeDisplayName } from "@/lib/attribute-normalizer";
+import { ATTRIBUTE_CATEGORIES } from "@/convex/attributeCategories";
 import { getTeamAbbreviation } from "@/lib/team-abbr";
 import { parseLineupFromURL, lineupToURLParams, type LineupPlayer } from "@/lib/lineup-url";
 import { API_KEY_STORAGE_KEY } from "@/lib/constants";
@@ -36,6 +39,8 @@ type PoolPlayer = {
   positions: string[];
   overall: number;
   playerImage: string | null;
+  attributes: Record<string, number>;
+  badges: { name: string; tier: string }[];
   threePointShot: number | null;
   speed: number | null;
   drivingDunk: number | null;
@@ -55,14 +60,17 @@ const POSITIONS = ["PG", "SG", "SF", "PF", "C"] as const;
 // Court spot geometry from the design (viewBox 100 x 56), left half; the
 // right half mirrors x.
 const SPOTS = [
-  { pos: "PG", x: 30, y: 28 },
-  { pos: "SG", x: 16, y: 13 },
-  { pos: "SF", x: 16, y: 43 },
-  { pos: "PF", x: 37, y: 17 },
-  { pos: "C", x: 38, y: 40 },
+  { pos: "PG", x: 36, y: 25 },
+  { pos: "SG", x: 27, y: 7 },
+  { pos: "SF", x: 27, y: 43 },
+  { pos: "PF", x: 15, y: 39 },
+  { pos: "C", x: 10, y: 18 },
 ];
 
 const CATS = ["ins", "out", "ply", "ath", "reb", "def"] as const;
+const ATTRIBUTE_KEYS = [...new Set(Object.values(ATTRIBUTE_CATEGORIES).flat())];
+const RATING_TIERS = ["Dark Matter", "Galaxy Opal", "Pink Diamond", "Diamond", "Amethyst", "Ruby", "Sapphire", "Emerald", "Gold", "Silver", "Bronze"];
+const BADGE_TIERS = ["Legendary", "Hall of Fame", "Gold", "Silver", "Bronze"];
 const CAT_LABELS: Record<(typeof CATS)[number], string> = {
   ins: "INSIDE",
   out: "OUTSIDE",
@@ -115,6 +123,52 @@ function MiniOvr({ ovr }: { ovr: number }) {
   );
 }
 
+function CourtDiagram({ matchupMode, guardLines }: { matchupMode: boolean; guardLines: { x1: number; y1: number; x2: number; y2: number }[] }) {
+  const line = "#c8a978";
+  const soft = "#decba7";
+  return (
+    <svg viewBox={`0 0 ${matchupMode ? 94 : 47} 50`} className="absolute inset-0 h-full w-full" aria-hidden="true">
+      <defs>
+        <pattern id="wood-planks" width="9.4" height="5" patternUnits="userSpaceOnUse">
+          <rect width="9.4" height="5" fill="#f4e4c3" />
+          <path d="M0 5H9.4 M9.4 0V5" stroke="#ead5ad" strokeWidth="0.12" />
+          <path d="M4.7 0V5" stroke="#f8edd5" strokeWidth="0.08" />
+        </pattern>
+      </defs>
+      <rect x="0.25" y="0.25" width={matchupMode ? 93.5 : 46.5} height="49.5" rx="0.7" fill="url(#wood-planks)" stroke={line} strokeWidth="0.5" />
+
+      {/* Left basket and half-court: dimensions use feet on a 94 × 50 NBA floor. */}
+      <rect x="0.25" y="17" width="18.75" height="16" fill="#ecd5a9" fillOpacity="0.42" stroke={line} strokeWidth="0.38" />
+      <circle cx="19" cy="25" r="6" fill="none" stroke={line} strokeWidth="0.38" />
+      <path d="M19 19 A6 6 0 0 1 19 31" fill="none" stroke={line} strokeWidth="0.38" strokeDasharray="0.8 0.8" />
+      <line x1="4" y1="22" x2="4" y2="28" stroke={line} strokeWidth="0.55" />
+      <circle cx="5.25" cy="25" r="0.75" fill="none" stroke={line} strokeWidth="0.45" />
+      <path d="M5.25 21 A4 4 0 0 1 5.25 29" fill="none" stroke={line} strokeWidth="0.38" />
+      <path d="M0.25 3 H14 M14 3 A23.75 23.75 0 0 1 14 47 M14 47 H0.25" fill="none" stroke={line} strokeWidth="0.45" />
+      <line x1="0.25" y1="22" x2="4" y2="22" stroke={soft} strokeWidth="0.25" />
+      <line x1="0.25" y1="28" x2="4" y2="28" stroke={soft} strokeWidth="0.25" />
+
+      {matchupMode && (
+        <>
+          <line x1="47" y1="0.25" x2="47" y2="49.75" stroke={line} strokeWidth="0.45" />
+          <circle cx="47" cy="25" r="6" fill="none" stroke={line} strokeWidth="0.38" />
+          <rect x="75" y="17" width="18.75" height="16" fill="#ecd5a9" fillOpacity="0.42" stroke={line} strokeWidth="0.38" />
+          <circle cx="75" cy="25" r="6" fill="none" stroke={line} strokeWidth="0.38" />
+          <path d="M75 19 A6 6 0 0 0 75 31" fill="none" stroke={line} strokeWidth="0.38" strokeDasharray="0.8 0.8" />
+          <line x1="90" y1="22" x2="90" y2="28" stroke={line} strokeWidth="0.55" />
+          <circle cx="88.75" cy="25" r="0.75" fill="none" stroke={line} strokeWidth="0.45" />
+          <path d="M88.75 21 A4 4 0 0 0 88.75 29" fill="none" stroke={line} strokeWidth="0.38" />
+          <path d="M93.75 3 H80 M80 3 A23.75 23.75 0 0 0 80 47 M80 47 H93.75" fill="none" stroke={line} strokeWidth="0.45" />
+        </>
+      )}
+
+      {matchupMode && guardLines.map((l, i) => (
+        <line key={i} x1={l.x1} y1={l.y1} x2={l.x2} y2={l.y2} stroke="#967d58" strokeWidth="0.22" strokeDasharray="0.8 1.1" />
+      ))}
+    </svg>
+  );
+}
+
 // ---- Court pieces -----------------------------------------------------------
 
 function CourtSlot({
@@ -134,8 +188,8 @@ function CourtSlot({
   pulsing: boolean;
   onRemove: () => void;
 }) {
-  const x = compareMode ? (side === "yours" ? spot.x : 100 - spot.x) : spot.x + 25;
-  const y = (spot.y / 56) * 100;
+  const x = compareMode ? (side === "yours" ? spot.x : 94 - spot.x) / 94 * 100 : spot.x / 47 * 100;
+  const y = (spot.y / 50) * 100;
   const { setNodeRef, isOver } = useDroppable({ id: `slot:${side}:${index}` });
   const drag = useDraggable({
     id: `chip:${side}:${index}`,
@@ -247,6 +301,12 @@ function Whiteboard() {
   const [sortF, setSortF] = useState<"ovr" | "az">("ovr");
   const [eraF, setEraF] = useState<"all" | TeamType>("all");
   const [minOvr, setMinOvr] = useState(0);
+  const [maxOvr, setMaxOvr] = useState(99);
+  const [ratingTierF, setRatingTierF] = useState("all");
+  const [attributeF, setAttributeF] = useState("all");
+  const [attributeMin, setAttributeMin] = useState(80);
+  const [badgeF, setBadgeF] = useState("all");
+  const [badgeTierF, setBadgeTierF] = useState("all");
   const [pickerOpen, setPickerOpen] = useState(false);
   const [pickerSide, setPickerSide] = useState<Side>("yours");
   const [matchupMode, setMatchupMode] = useState(false);
@@ -332,6 +392,11 @@ function Whiteboard() {
     [yoursFilled, oppsFilled]
   );
 
+  const badgeOptions = useMemo(() => {
+    if (!players) return [];
+    return [...new Set(players.flatMap((p) => (p.badges ?? []).map((badge) => badge.name)))].sort();
+  }, [players]);
+
   const pool = useMemo(() => {
     if (!players) return [];
     const query = q.trim().toLowerCase();
@@ -340,12 +405,16 @@ function Whiteboard() {
         (p) =>
           (posF === "ALL" || p.positions.includes(posF)) &&
           (eraF === "all" || p.teamType === eraF) &&
-          p.overall >= minOvr &&
+          p.overall >= minOvr && p.overall <= maxOvr &&
+          (ratingTierF === "all" || getRatingTier(p.overall) === ratingTierF) &&
+          (attributeF === "all" || (p.attributes?.[attributeF] ?? -1) >= attributeMin) &&
+          (badgeF === "all" || (p.badges ?? []).some((badge) => badge.name === badgeF)) &&
+          (badgeTierF === "all" || (p.badges ?? []).some((badge) => badge.tier === badgeTierF)) &&
           (!query || p.name.toLowerCase().includes(query))
       )
       .sort((a, b) => (sortF === "ovr" ? b.overall - a.overall : a.name.localeCompare(b.name)))
       .slice(0, POOL_LIMIT);
-  }, [players, q, posF, eraF, minOvr, sortF]);
+  }, [players, q, posF, eraF, minOvr, maxOvr, ratingTierF, attributeF, attributeMin, badgeF, badgeTierF, sortF]);
 
   const place = (side: Side, index: number, p: PoolPlayer) => {
     const setter = side === "yours" ? setYours : setOpps;
@@ -534,7 +603,7 @@ function Whiteboard() {
   );
 
   const guardLines = SPOTS.map((s, i) =>
-    yours[i] && opps[i] ? { x1: s.x + 2.5, y1: s.y, x2: 100 - s.x - 2.5, y2: s.y } : null
+    yours[i] && opps[i] ? { x1: s.x + 2.5, y1: s.y, x2: 94 - s.x - 2.5, y2: s.y } : null
   ).filter((l): l is NonNullable<typeof l> => l !== null);
 
   const shareLineup = () => {
@@ -698,29 +767,13 @@ function Whiteboard() {
             {/* Court + analysis */}
             <div className="min-w-0">
               <div
-                className="relative aspect-[16/9.4] overflow-hidden rounded-2xl border border-[#e5e2da] bg-[#f6f4ee] animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:animate-none"
+                className={cn(
+                  "relative mx-auto overflow-hidden rounded-2xl border border-[#d9c49a] bg-[#f4e4c3] shadow-[0_22px_55px_-38px_rgba(81,59,29,0.7)] transition-[max-width,aspect-ratio] duration-500 ease-out animate-[rise-in_350ms_cubic-bezier(0.23,1,0.32,1)_both] motion-reduce:transition-none motion-reduce:animate-none",
+                  matchupMode ? "aspect-[94/50] w-full max-w-none" : "aspect-[47/50] w-full max-w-[680px]"
+                )}
                 style={{ animationDelay: "100ms" }}
               >
-                <svg viewBox="0 0 100 56" preserveAspectRatio="none" className="absolute inset-0 h-full w-full">
-                  {matchupMode && <line x1="50" y1="0" x2="50" y2="56" stroke="#d9d4c7" strokeWidth="0.25" />}
-                  <circle cx="50" cy="28" r="7" fill="none" stroke="#d9d4c7" strokeWidth="0.25" />
-                  <rect x="0" y="18" width="14" height="20" fill="none" stroke="#d9d4c7" strokeWidth="0.25" />
-                  {matchupMode && <rect x="86" y="18" width="14" height="20" fill="none" stroke="#d9d4c7" strokeWidth="0.25" />}
-                  <path d="M 0 6 Q 30 28 0 50" fill="none" stroke="#d9d4c7" strokeWidth="0.25" />
-                  {matchupMode && <path d="M 100 6 Q 70 28 100 50" fill="none" stroke="#d9d4c7" strokeWidth="0.25" />}
-                  {guardLines.map((l, i) => (
-                    <line
-                      key={i}
-                      x1={l.x1}
-                      y1={l.y1}
-                      x2={l.x2}
-                      y2={l.y2}
-                      stroke="#b5b0a1"
-                      strokeWidth="0.3"
-                      strokeDasharray="1 1.6"
-                    />
-                  ))}
-                </svg>
+                <CourtDiagram matchupMode={matchupMode} guardLines={guardLines} />
 
                 <span className={cn("absolute top-2.5 font-plex text-[8.5px] tracking-[0.1em] text-[#b5b0a1]", matchupMode ? "left-3.5" : "left-1/2 -translate-x-1/2")}>
                   YOUR FIVE · {yoursFilled.length}/5
@@ -738,7 +791,7 @@ function Whiteboard() {
                       <b className="text-[#1a1918]">{oppOvr} OVR</b>
                     </>
                   ) : (
-                    "OPEN HALF — ADD FROM THE POOL"
+                    "OPEN HALF — ADD AN OPPONENT"
                   )}
                 </span>}
 
@@ -882,13 +935,12 @@ function Whiteboard() {
 
           {pickerOpen && (
             <div
-              className="fixed inset-0 z-50 flex items-end justify-center bg-[#1a1918]/35 p-0 backdrop-blur-[2px] sm:items-center sm:p-6"
+              className="pointer-events-none fixed inset-0 z-50 flex items-end justify-center bg-[#1a1918]/35 backdrop-blur-[2px] lg:items-stretch lg:justify-end lg:bg-transparent lg:backdrop-blur-none"
               role="dialog"
               aria-modal="true"
               aria-label={`Choose a player for ${pickerSide === "yours" ? "your lineup" : "the opponent"}`}
-              onMouseDown={(e) => { if (e.target === e.currentTarget) setPickerOpen(false); }}
             >
-              <div className="flex max-h-[88vh] w-full max-w-[760px] flex-col overflow-hidden rounded-t-[22px] border border-[#d9d4c7] bg-[#fffdf8] shadow-[0_30px_80px_-24px_rgba(26,25,24,0.55)] sm:rounded-[22px]">
+              <div className="pointer-events-auto flex max-h-[90vh] w-full flex-col overflow-hidden rounded-t-[22px] border border-[#d9d4c7] bg-[#fffdf8] shadow-[0_30px_80px_-24px_rgba(26,25,24,0.55)] lg:my-3 lg:mr-3 lg:max-h-none lg:w-[440px] lg:rounded-[22px]">
                 <div className="flex items-start justify-between gap-4 border-b border-[#e5e2da] px-5 py-4">
                   <div>
                     <div className="font-plex text-[9px] tracking-[0.12em] text-[#8a8577]">
@@ -907,7 +959,7 @@ function Whiteboard() {
                     <input autoFocus value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search any player or legend…" className="min-w-0 flex-1 border-0 bg-transparent text-[14px] outline-none placeholder:text-[#b5b0a1]" />
                     <span className="font-plex text-[8px] text-[#b5b0a1]">{pool.length} SHOWN</span>
                   </div>
-                  <div className="mt-3 grid gap-3 sm:grid-cols-[1fr_1fr_auto]">
+                  <div className="mt-3 grid gap-3 sm:grid-cols-2">
                     <div>
                       <div className="mb-1.5 flex items-center gap-1.5 font-plex text-[8px] tracking-[0.08em] text-[#8a8577]"><SlidersHorizontal className="h-3 w-3" /> POSITION</div>
                       <div className="flex flex-wrap gap-1.5">
@@ -920,13 +972,49 @@ function Whiteboard() {
                         {([['all','ALL'],['curr','CURRENT'],['class','CLASSIC'],['allt','ALL-TIME']] as const).map(([value,label]) => <button key={value} type="button" onClick={() => setEraF(value)} className={cn("cursor-pointer rounded-full border px-2.5 py-1 font-plex text-[8px] font-bold", eraF === value ? "border-[#1a1918] bg-[#1a1918] text-white" : "border-[#e5e2da] bg-[#faf9f5] text-[#8a8577]")}>{label}</button>)}
                       </div>
                     </div>
-                    <label className="block min-w-[130px]">
-                      <span className="mb-1.5 block font-plex text-[8px] tracking-[0.08em] text-[#8a8577]">MIN OVR · {minOvr || "ANY"}</span>
-                      <input type="range" min="0" max="95" step="5" value={minOvr} onChange={(e) => setMinOvr(Number(e.target.value))} className="w-full accent-[#1a1918]" />
+                    <label className="block">
+                      <span className="mb-1.5 block font-plex text-[8px] tracking-[0.08em] text-[#8a8577]">CARD TIER</span>
+                      <select value={ratingTierF} onChange={(e) => setRatingTierF(e.target.value)} className="h-9 w-full rounded-[9px] border border-[#e5e2da] bg-[#faf9f5] px-2.5 text-[11px] outline-none focus:border-[#1a1918]">
+                        <option value="all">Any tier</option>
+                        {RATING_TIERS.map((tier) => <option key={tier} value={tier}>{tier}</option>)}
+                      </select>
+                    </label>
+                    <div>
+                      <span className="mb-1.5 block font-plex text-[8px] tracking-[0.08em] text-[#8a8577]">OVERALL RANGE</span>
+                      <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+                        <input aria-label="Minimum overall" type="number" min="0" max="99" value={minOvr} onChange={(e) => setMinOvr(Math.min(Number(e.target.value), maxOvr))} className="h-9 min-w-0 rounded-[9px] border border-[#e5e2da] bg-[#faf9f5] px-2.5 text-[11px] outline-none focus:border-[#1a1918]" />
+                        <span className="font-plex text-[8px] text-[#b5b0a1]">TO</span>
+                        <input aria-label="Maximum overall" type="number" min="0" max="99" value={maxOvr} onChange={(e) => setMaxOvr(Math.max(Number(e.target.value), minOvr))} className="h-9 min-w-0 rounded-[9px] border border-[#e5e2da] bg-[#faf9f5] px-2.5 text-[11px] outline-none focus:border-[#1a1918]" />
+                      </div>
+                    </div>
+                    <label className="block">
+                      <span className="mb-1.5 block font-plex text-[8px] tracking-[0.08em] text-[#8a8577]">SPECIFIC ATTRIBUTE</span>
+                      <select value={attributeF} onChange={(e) => setAttributeF(e.target.value)} className="h-9 w-full rounded-[9px] border border-[#e5e2da] bg-[#faf9f5] px-2.5 text-[11px] outline-none focus:border-[#1a1918]">
+                        <option value="all">Any attribute</option>
+                        {ATTRIBUTE_KEYS.map((key) => <option key={key} value={key}>{getAttributeDisplayName(key)}</option>)}
+                      </select>
+                    </label>
+                    <label className={cn("block", attributeF === "all" && "opacity-45")}>
+                      <span className="mb-1.5 block font-plex text-[8px] tracking-[0.08em] text-[#8a8577]">ATTRIBUTE MIN · {attributeMin}</span>
+                      <input disabled={attributeF === "all"} type="range" min="25" max="99" value={attributeMin} onChange={(e) => setAttributeMin(Number(e.target.value))} className="w-full accent-[#1a1918]" />
+                    </label>
+                    <label className="block">
+                      <span className="mb-1.5 block font-plex text-[8px] tracking-[0.08em] text-[#8a8577]">SPECIFIC BADGE</span>
+                      <select value={badgeF} onChange={(e) => setBadgeF(e.target.value)} className="h-9 w-full rounded-[9px] border border-[#e5e2da] bg-[#faf9f5] px-2.5 text-[11px] outline-none focus:border-[#1a1918]">
+                        <option value="all">Any badge</option>
+                        {badgeOptions.map((badge) => <option key={badge} value={badge}>{badge}</option>)}
+                      </select>
+                    </label>
+                    <label className="block">
+                      <span className="mb-1.5 block font-plex text-[8px] tracking-[0.08em] text-[#8a8577]">BADGE TIER</span>
+                      <select value={badgeTierF} onChange={(e) => setBadgeTierF(e.target.value)} className="h-9 w-full rounded-[9px] border border-[#e5e2da] bg-[#faf9f5] px-2.5 text-[11px] outline-none focus:border-[#1a1918]">
+                        <option value="all">Any badge tier</option>
+                        {BADGE_TIERS.map((tier) => <option key={tier} value={tier}>{tier}</option>)}
+                      </select>
                     </label>
                   </div>
                   <div className="mt-3 flex items-center justify-between">
-                    <button type="button" onClick={() => { setQ(""); setPosF("ALL"); setEraF("all"); setMinOvr(0); }} className="cursor-pointer border-0 bg-transparent font-plex text-[8px] text-[#8a8577] underline underline-offset-4">CLEAR FILTERS</button>
+                    <button type="button" onClick={() => { setQ(""); setPosF("ALL"); setEraF("all"); setMinOvr(0); setMaxOvr(99); setRatingTierF("all"); setAttributeF("all"); setAttributeMin(80); setBadgeF("all"); setBadgeTierF("all"); }} className="cursor-pointer border-0 bg-transparent font-plex text-[8px] text-[#8a8577] underline underline-offset-4">CLEAR FILTERS</button>
                     <button type="button" onClick={() => setSortF((s) => s === "ovr" ? "az" : "ovr")} className="cursor-pointer border-0 bg-transparent font-plex text-[8px] text-[#57534a]">SORT · {sortF === "ovr" ? "OVR ↓" : "A–Z"}</button>
                   </div>
                 </div>
@@ -937,7 +1025,7 @@ function Whiteboard() {
                   )) : Array.from({ length: 8 }, (_, i) => <div key={i} className="h-12 animate-pulse border-b border-[#faf8f2] bg-[#f1efe8]" />)}
                   {players && pool.length === 0 && <div className="px-5 py-16 text-center font-plex text-[9px] tracking-[0.08em] text-[#b5b0a1]">NO MATCHES · TRY WIDENING THE FILTERS</div>}
                 </div>
-                <div className="border-t border-[#e5e2da] bg-[#faf9f5] px-5 py-3 font-plex text-[8px] text-[#8a8577]">TAP A PLAYER TO ADD · DUPLICATE 2K VERSIONS STAY SEPARATE BY ERA + TEAM</div>
+                <div className="border-t border-[#e5e2da] bg-[#faf9f5] px-5 py-3 font-plex text-[8px] text-[#8a8577]">DRAG ONTO A COURT SLOT · TAP TO AUTO-PLACE · VERSIONS STAY SEPARATE BY ERA + TEAM</div>
               </div>
             </div>
           )}

--- a/app/lineups/page.tsx
+++ b/app/lineups/page.tsx
@@ -110,6 +110,104 @@ function shortMeta(p: PoolPlayer) {
   return `${p.positions.join("/")} · ${era}`;
 }
 
+function rating(p: PoolPlayer, key: string) {
+  return p.attributes?.[key] ?? 0;
+}
+
+function hasAnyBadge(p: PoolPlayer, names: string[]) {
+  const wanted = names.map((name) => name.toLowerCase());
+  return (p.badges ?? []).some((badge) => wanted.some((name) => badge.name.toLowerCase().includes(name)));
+}
+
+function grade(score: number) {
+  if (score >= 92) return "A+";
+  if (score >= 87) return "A";
+  if (score >= 82) return "B+";
+  if (score >= 76) return "B";
+  if (score >= 70) return "C+";
+  if (score >= 64) return "C";
+  return "D";
+}
+
+function buildLineupReport(players: PoolPlayer[]) {
+  if (players.length === 0) return null;
+  const mean = (values: number[]) => Math.round(values.reduce((sum, n) => sum + n, 0) / values.length);
+  const topMean = (values: number[], n: number) => mean([...values].sort((a, b) => b - a).slice(0, Math.min(n, values.length)));
+  const count = (test: (p: PoolPlayer) => boolean) => players.filter(test).length;
+  const credibleShooter = (p: PoolPlayer) => rating(p, "threePointShot") >= 85 || hasAnyBadge(p, ["set shot", "deadeye", "shifty shooter"]);
+  const shooters = count(credibleShooter);
+  const creators = count((p) => rating(p, "ballHandle") >= 85 && rating(p, "passAccuracy") >= 78);
+  const secondaryCreators = count((p) => rating(p, "ballHandle") >= 78 && rating(p, "passAccuracy") >= 72);
+  const rimPressure = count((p) => Math.max(rating(p, "drivingLayup"), rating(p, "drivingDunk")) >= 85);
+  const poa = count((p) => rating(p, "perimeterDefense") >= 84 && rating(p, "agility") >= 78 || hasAnyBadge(p, ["on-ball menace", "challenger"]));
+  const rimProtectors = count((p) => Math.max(rating(p, "interiorDefense"), rating(p, "block")) >= 84 || hasAnyBadge(p, ["paint patroller", "high-flying denier"]));
+  const rebounders = count((p) => Math.max(rating(p, "defensiveRebound"), rating(p, "offensiveRebound")) >= 82);
+  const nonShooters = count((p) => !credibleShooter(p) && rating(p, "threePointShot") < 72);
+
+  const spacing = Math.max(25, Math.min(99, mean(players.map((p) => rating(p, "threePointShot"))) + shooters * 3 - nonShooters * 7));
+  const creation = mean(players.map((p) => Math.round((rating(p, "ballHandle") + rating(p, "passAccuracy") + rating(p, "speedWithBall")) / 3)));
+  const pressure = mean(players.map((p) => Math.round((Math.max(rating(p, "drivingLayup"), rating(p, "drivingDunk")) + rating(p, "drawFoul")) / 2)));
+  const offense = Math.round(spacing * 0.35 + creation * 0.35 + pressure * 0.2 + mean(players.map((p) => p.cats.ins ?? 50)) * 0.1);
+  const pointDefense = topMean(players.map((p) => Math.round((rating(p, "perimeterDefense") + rating(p, "agility") + rating(p, "steal")) / 3)), 2);
+  const backline = topMean(players.map((p) => Math.round((rating(p, "interiorDefense") + rating(p, "block") + rating(p, "helpDefenseIQ")) / 3)), 2);
+  const glass = topMean(players.map((p) => Math.max(rating(p, "defensiveRebound"), rating(p, "offensiveRebound"))), 2);
+  const defense = Math.round(pointDefense * 0.45 + backline * 0.4 + glass * 0.15);
+  const roleCoverage = [creators >= 1, shooters >= Math.min(3, players.length), poa >= 1, rimProtectors >= 1, rebounders >= 1].filter(Boolean).length;
+  const fit = Math.max(35, Math.min(99, 55 + roleCoverage * 9 - Math.max(0, nonShooters - 1) * 8 - Math.max(0, creators - 2) * 4));
+  const switchable = count((p) => rating(p, "perimeterDefense") >= 78 && rating(p, "interiorDefense") >= 68 && rating(p, "strength") >= 65);
+  const versatility = Math.min(99, 48 + switchable * 8 + secondaryCreators * 5 + shooters * 4);
+
+  const strengths: string[] = [];
+  const risks: string[] = [];
+  if (shooters >= 4) strengths.push(`${shooters} credible shooters support five-out spacing.`);
+  else if (shooters >= 3) strengths.push(`${shooters} credible shooters preserve driving lanes.`);
+  if (creators >= 2) strengths.push(`${creators} primary-level creators keep the offense alive after help.`);
+  else if (creators === 1 && secondaryCreators >= 2) strengths.push("Clear primary creator with a usable secondary handler.");
+  if (poa >= 1 && rimProtectors >= 1) strengths.push("Point-of-attack resistance is backed by real rim protection.");
+  if (rimPressure >= 2) strengths.push(`${rimPressure} rim-pressure threats can force rotations.`);
+  if (rebounders >= 2) strengths.push(`${rebounders} plus rebounders should finish defensive possessions.`);
+
+  if (creators === 0) risks.push("No reliable primary creator; organized defenses can flatten the offense.");
+  else if (creators === 1 && secondaryCreators < 2) risks.push("One-handler dependency: blitzes can force the ball into weak creation.");
+  if (nonShooters >= 2) risks.push(`${nonShooters} non-shooters let one defender guard two spaces near the paint.`);
+  if (poa === 0) risks.push("No clean point-of-attack stopper for elite guards.");
+  if (rimProtectors === 0) risks.push("No backline rim deterrent; perimeter mistakes become layups.");
+  if (rebounders === 0) risks.push("Weak rebounding coverage may waste otherwise good defensive possessions.");
+
+  const identity = spacing >= 88 && creators >= 2
+    ? "Five-out creation machine"
+    : shooters >= 3 && rimPressure >= 2
+      ? "Drive-and-kick pressure lineup"
+      : defense >= offense && poa >= 1
+        ? "Defense-first transition five"
+        : creators >= 1 && rimProtectors >= 1
+          ? "Balanced pick-and-roll five"
+          : "Talent-rich, role-light lineup";
+  const recommendation = risks[0]
+    ? `First fix: ${risks[0].replace(/^[A-Z]/, (c) => c.toLowerCase())}`
+    : "No critical coverage hole. Optimize for the opponent rather than adding more raw overall.";
+
+  return {
+    identity,
+    grades: [
+      { label: "OFFENSE", value: grade(offense), score: offense },
+      { label: "DEFENSE", value: grade(defense), score: defense },
+      { label: "FIT", value: grade(fit), score: fit },
+      { label: "VERSATILITY", value: grade(versatility), score: versatility },
+    ],
+    coverage: [
+      { label: "CREATORS", value: creators, ok: creators >= 1 },
+      { label: "SHOOTERS", value: shooters, ok: shooters >= Math.min(3, players.length) },
+      { label: "POA", value: poa, ok: poa >= 1 },
+      { label: "RIM", value: rimProtectors, ok: rimProtectors >= 1 },
+      { label: "REBOUND", value: rebounders, ok: rebounders >= 1 },
+    ],
+    strengths: strengths.slice(0, 3),
+    risks: risks.slice(0, 3),
+    recommendation,
+  };
+}
+
 function MiniOvr({ ovr }: { ovr: number }) {
   return (
     <span
@@ -583,6 +681,7 @@ function Whiteboard() {
       },
     ];
   }, [yoursFilled, oppsFilled, hasOpp, yourOvr, oppOvr]);
+  const lineupReport = useMemo(() => buildLineupReport(yoursFilled), [yoursFilled]);
 
   const duels = useMemo(
     () =>
@@ -812,8 +911,62 @@ function Whiteboard() {
 
               </div>
 
-              {/* Tape + read */}
-              <div className="mt-3 grid grid-cols-[repeat(auto-fit,minmax(min(100%,300px),1fr))] gap-3">
+              {/* Single-lineup report */}
+              {!hasOpp && lineupReport && (
+                <div className="mt-3 overflow-hidden rounded-[14px] border border-[#e5e2da] bg-white">
+                  <div className="grid gap-3 border-b border-[#f1efe8] px-[18px] py-3 lg:grid-cols-[minmax(220px,1.5fr)_repeat(4,minmax(72px,0.55fr))] lg:items-center">
+                    <div>
+                      <div className="font-plex text-[8px] tracking-[0.12em] text-[#8a8577]">LINEUP IDENTITY · {yoursFilled.length}/5</div>
+                      <div className="mt-1 font-display text-[19px] font-bold tracking-[-0.02em]">{lineupReport.identity}</div>
+                    </div>
+                    {lineupReport.grades.map((item) => (
+                      <div key={item.label} className="flex items-center justify-between gap-2 rounded-[10px] border border-[#efece4] bg-[#faf9f5] px-3 py-2 lg:block">
+                        <span className="font-plex text-[7.5px] tracking-[0.08em] text-[#8a8577]">{item.label}</span>
+                        <div className="font-display text-[22px] leading-none font-bold" title={`Heuristic score ${item.score}/99`}>{item.value}</div>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-2 border-b border-[#f1efe8] px-[18px] py-2.5">
+                    <span className="mr-1 font-plex text-[8px] tracking-[0.1em] text-[#8a8577]">ROLE COVERAGE</span>
+                    {lineupReport.coverage.map((item) => (
+                      <span key={item.label} className={cn("inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-plex text-[8px] font-bold", item.ok ? "border-[#b8d8c3] bg-[#f1faf4] text-[#0a7f3f]" : "border-[#ead0ca] bg-[#fff5f2] text-[#c03a2b]")}>
+                        <i className={cn("h-1.5 w-1.5 rounded-full", item.ok ? "bg-[#0a7f3f]" : "bg-[#c03a2b]")} />
+                        {item.label} · {item.value}
+                      </span>
+                    ))}
+                  </div>
+
+                  <div className="grid gap-0 md:grid-cols-2">
+                    <div className="border-b border-[#f1efe8] px-[18px] py-3 md:border-r md:border-b-0">
+                      <div className="mb-2 font-plex text-[8px] font-bold tracking-[0.1em] text-[#0a7f3f]">WHAT TRAVELS</div>
+                      <div className="flex flex-col gap-1.5">
+                        {(lineupReport.strengths.length ? lineupReport.strengths : ["Add more players to reveal lineup strengths."]).map((text) => <div key={text} className="flex gap-2 text-[11.5px] leading-[1.45] text-[#57534a]"><b className="text-[#0a7f3f]">+</b>{text}</div>)}
+                      </div>
+                    </div>
+                    <div className="px-[18px] py-3">
+                      <div className="mb-2 font-plex text-[8px] font-bold tracking-[0.1em] text-[#c03a2b]">HOW IT BREAKS</div>
+                      <div className="flex flex-col gap-1.5">
+                        {(lineupReport.risks.length ? lineupReport.risks : ["No critical coverage hole detected yet."]).map((text) => <div key={text} className="flex gap-2 text-[11.5px] leading-[1.45] text-[#57534a]"><b className="text-[#c03a2b]">−</b>{text}</div>)}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex items-start gap-2 border-t border-[#f1efe8] bg-[#faf9f5] px-[18px] py-2.5 text-[11px] leading-[1.5] text-[#57534a]">
+                    <span className="shrink-0 font-plex text-[8px] font-bold tracking-[0.08em] text-[#9a6700]">NEXT MOVE</span>
+                    <span>{lineupReport.recommendation}</span>
+                  </div>
+                </div>
+              )}
+
+              {!hasOpp && !lineupReport && (
+                <div className="mt-3 rounded-[14px] border border-[#e5e2da] bg-white px-[18px] py-4">
+                  <div className="font-plex text-[8px] tracking-[0.12em] text-[#8a8577]">LINEUP REPORT</div>
+                  <div className="mt-1 text-[12px] text-[#57534a]">Drag in your first player to start the analysis.</div>
+                </div>
+              )}
+
+              {/* Matchup tape + read */}
+              {hasOpp && <div className="mt-3 grid grid-cols-[repeat(auto-fit,minmax(min(100%,300px),1fr))] gap-3">
                 <div className="rounded-[14px] border border-[#e5e2da] bg-white px-[18px] py-3.5">
                   <div className="mb-3 flex items-center justify-between">
                     <span className="font-plex text-[9px] tracking-[0.12em] text-[#8a8577]">
@@ -870,7 +1023,7 @@ function Whiteboard() {
                     ))}
                   </div>
                 </div>
-              </div>
+              </div>}
 
               {/* Duels */}
               {hasOpp && duels.length > 0 && (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
@@ -24,19 +24,33 @@ const MONO_LABEL = "font-plex text-[12px] tracking-[0.14em] text-[#8a8577]";
 const PILL_CTA =
   "rounded-full bg-[#1a1918] text-[#faf9f5] no-underline font-semibold transition-[background,transform] duration-150 ease-out hover:bg-[#333] active:scale-[0.97] motion-reduce:transition-none cursor-pointer";
 
-const TEASER_URL =
-  "/api/players?position=guard&era=all&three_ball_gte=85&sort=overall:desc";
+type DemoPlayer = {
+  name: string;
+  slug: string;
+  team: string;
+  teamType: "curr" | "class" | "allt";
+  positions: string[];
+  overall: number;
+  playerImage: string | null;
+  threePointShot: number | null;
+};
 
-// Static teaser rows mirroring the design mock — the sentence-query itself is
-// interactive on /playground; the landing only demonstrates the idea.
-const TEASER_ROWS = [
-  { name: "Shai Gilgeous-Alexander", meta: "PG · OKC", era: "CURRENT", ovr: 98, nbaId: 1628983, init: "", tpt: 85 },
-  { name: "Luka Doncic", meta: "PG · LAL", era: "CURRENT", ovr: 97, nbaId: 1629029, init: "", tpt: 88 },
-  { name: "Stephen Curry", meta: "PG · GSW", era: "CURRENT", ovr: 96, nbaId: 201939, init: "", tpt: 99 },
-  { name: "Reggie Miller", meta: "SG · IND '95", era: "CLASSIC", ovr: 94, nbaId: 0, init: "RM", tpt: 95 },
-  { name: "Damian Lillard", meta: "PG · MIL", era: "CURRENT", ovr: 94, nbaId: 203081, init: "", tpt: 93 },
-  { name: "Ray Allen", meta: "SG · BOS '08", era: "CLASSIC", ovr: 93, nbaId: 0, init: "RA", tpt: 97 },
-];
+const DEMO_POSITIONS = [
+  { label: "guards", value: "guard", positions: ["PG", "SG"] },
+  { label: "wings", value: "wing", positions: ["SG", "SF"] },
+  { label: "bigs", value: "big", positions: ["PF", "C"] },
+] as const;
+const DEMO_ERAS = [
+  { label: "any era", value: "all" },
+  { label: "current", value: "curr" },
+  { label: "classic", value: "class" },
+  { label: "all-time", value: "allt" },
+] as const;
+const DEMO_THRESHOLDS = [80, 85, 90] as const;
+const DEMO_SORTS = [
+  { label: "overall", value: "overall" },
+  { label: "3PT", value: "three_ball" },
+] as const;
 
 const BOARD_MINI = [
   { rank: 1, name: "Thunder", avg: "82.4", w: "96%" },
@@ -59,10 +73,6 @@ const ENDPOINTS = [
   { path: "GET /api/players/slug/:slug", note: "one player, full detail", href: "/docs/endpoints/players" },
   { path: "GET /api/teams/:team/roster", note: "full team rosters", href: "/docs/endpoints/teams" },
 ];
-
-function headshotUrl(nbaId: number) {
-  return `https://cdn.nba.com/headshots/nba/latest/1040x760/${nbaId}.png`;
-}
 
 function weekOfYear(d: Date) {
   const start = new Date(d.getFullYear(), 0, 1);
@@ -108,12 +118,16 @@ function SlotChevron() {
   );
 }
 
-function QuerySlot({ children }: { children: React.ReactNode }) {
+function QuerySlot({ children, onClick }: { children: React.ReactNode; onClick: () => void }) {
   return (
-    <span className="inline-flex items-center gap-1.5 border-b-2 border-dashed border-[#d9d4c7] px-[3px] pb-px font-extrabold text-[#1a1918]">
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex cursor-pointer items-center gap-1.5 border-0 border-b-2 border-dashed border-[#d9d4c7] bg-transparent px-[3px] pb-px font-[inherit] font-extrabold text-[#1a1918] transition-colors hover:border-[#1a1918] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#1a1918]"
+    >
       {children}
       <SlotChevron />
-    </span>
+    </button>
   );
 }
 
@@ -131,6 +145,10 @@ function SectionHeading({ eyebrow, title }: { eyebrow: string; title: string }) 
 export default function Home() {
   const [showRegistration, setShowRegistration] = useState(false);
   const [hasApiKey, setHasApiKey] = useState(false);
+  const [demoPosition, setDemoPosition] = useState(0);
+  const [demoEra, setDemoEra] = useState(0);
+  const [demoThreshold, setDemoThreshold] = useState(1);
+  const [demoSort, setDemoSort] = useState(0);
   const router = useRouter();
 
   const stats = useQuery(api.players.getStats);
@@ -139,6 +157,25 @@ export default function Home() {
     sortBy: "overall-desc",
     limit: 9,
   });
+  const demoPlayers = useQuery(api.players.getPlaygroundPlayers) as DemoPlayer[] | undefined;
+
+  const demoResults = useMemo(() => {
+    if (!demoPlayers) return [];
+    const position = DEMO_POSITIONS[demoPosition];
+    const era = DEMO_ERAS[demoEra].value;
+    const threshold = DEMO_THRESHOLDS[demoThreshold];
+    return demoPlayers
+      .filter((p) => position.positions.some((pos) => p.positions.includes(pos)))
+      .filter((p) => era === "all" || p.teamType === era)
+      .filter((p) => (p.threePointShot ?? -1) >= threshold)
+      .sort((a, b) =>
+        DEMO_SORTS[demoSort].value === "overall"
+          ? b.overall - a.overall || (b.threePointShot ?? 0) - (a.threePointShot ?? 0)
+          : (b.threePointShot ?? 0) - (a.threePointShot ?? 0) || b.overall - a.overall
+      );
+  }, [demoPlayers, demoPosition, demoEra, demoThreshold, demoSort]);
+
+  const teaserUrl = `/api/players?position=${DEMO_POSITIONS[demoPosition].value}&era=${DEMO_ERAS[demoEra].value}&three_ball_gte=${DEMO_THRESHOLDS[demoThreshold]}&sort=${DEMO_SORTS[demoSort].value}:desc`;
 
   useEffect(() => {
     setHasApiKey(!!localStorage.getItem(API_KEY_STORAGE_KEY));
@@ -160,7 +197,7 @@ export default function Home() {
 
   const copyTeaserUrl = () => {
     navigator.clipboard
-      .writeText(`https://api.nba2kapi.com${TEASER_URL}`)
+      .writeText(`https://api.nba2kapi.com${teaserUrl}`)
       .then(() => toast.success("Request URL copied"));
   };
 
@@ -336,15 +373,29 @@ export default function Home() {
               </Link>
             </div>
             <div className="font-display text-[clamp(19px,2.2vw,25px)] leading-[1.7] font-semibold tracking-[-0.02em] text-[#57534a]">
-              Show me <QuerySlot>guards</QuerySlot> from <QuerySlot>any era</QuerySlot> with{" "}
-              <QuerySlot>3PT ≥ 85</QuerySlot>, ranked by <QuerySlot>overall</QuerySlot>
+              Show me{" "}
+              <QuerySlot onClick={() => setDemoPosition((v) => (v + 1) % DEMO_POSITIONS.length)}>
+                {DEMO_POSITIONS[demoPosition].label}
+              </QuerySlot>{" "}
+              from{" "}
+              <QuerySlot onClick={() => setDemoEra((v) => (v + 1) % DEMO_ERAS.length)}>
+                {DEMO_ERAS[demoEra].label}
+              </QuerySlot>{" "}
+              with{" "}
+              <QuerySlot onClick={() => setDemoThreshold((v) => (v + 1) % DEMO_THRESHOLDS.length)}>
+                3PT ≥ {DEMO_THRESHOLDS[demoThreshold]}
+              </QuerySlot>
+              , ranked by{" "}
+              <QuerySlot onClick={() => setDemoSort((v) => (v + 1) % DEMO_SORTS.length)}>
+                {DEMO_SORTS[demoSort].label}
+              </QuerySlot>
             </div>
             <div className="mt-3.5 flex items-center overflow-hidden rounded-[10px] bg-[#1a1918]">
               <span className="shrink-0 bg-white/12 px-[13px] py-[9px] font-plex text-[9.5px] text-[#faf9f5]">
                 GET
               </span>
               <span className="flex-1 overflow-hidden px-3.5 font-plex text-[11px] text-ellipsis whitespace-nowrap text-[#faf9f5]">
-                {TEASER_URL}
+                {teaserUrl}
               </span>
               <button
                 type="button"
@@ -373,41 +424,40 @@ export default function Home() {
                     3PT ●
                   </span>
                 </div>
-                {TEASER_ROWS.map((r, i) => (
+                {demoResults.slice(0, 6).map((r, i) => (
                   <Link
-                    key={r.name}
-                    href="/playground"
+                    key={`${r.slug}:${r.teamType}:${r.team}`}
+                    href={`/players/${r.slug}?type=${r.teamType}&team=${encodeURIComponent(r.team)}`}
                     className="grid grid-cols-[34px_30px_minmax(150px,1fr)_90px_54px_56px] items-center gap-3 border-b border-[#faf8f2] px-5 py-2 text-[#1a1918] no-underline transition-colors duration-100 hover:bg-[#faf8f2]"
                   >
                     <span className="font-plex text-[10px] text-[#b5b0a1]">{i + 1}</span>
                     <div
-                      className="flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-[#f1efe8] bg-cover bg-top font-display text-[10px] font-extrabold text-[#57534a]"
-                      style={
-                        r.nbaId ? { backgroundImage: `url('${headshotUrl(r.nbaId)}')` } : undefined
-                      }
+                      className="relative flex h-7 w-7 items-center justify-center overflow-hidden rounded-full bg-[#f1efe8] font-display text-[10px] font-extrabold text-[#57534a]"
                     >
-                      {r.init}
+                      {r.playerImage ? (
+                        <Image src={r.playerImage} alt="" fill sizes="28px" className="object-cover object-top" />
+                      ) : r.name.split(" ").map((part) => part[0]).join("").slice(0, 2)}
                     </div>
                     <div className="flex min-w-0 items-baseline gap-2">
                       <span className="overflow-hidden text-[13.5px] font-semibold text-ellipsis whitespace-nowrap">
                         {r.name}
                       </span>
                       <span className="whitespace-nowrap font-plex text-[8.5px] text-[#8a8577]">
-                        {r.meta}
+                        {r.positions.join("/")} · {getTeamAbbreviation(r.team)}
                       </span>
                     </div>
                     <span
                       className="font-plex text-[8px] font-bold tracking-[0.08em]"
-                      style={{ color: r.era === "CLASSIC" ? "#9a6700" : "#8a8577" }}
+                      style={{ color: r.teamType === "curr" ? "#8a8577" : "#9a6700" }}
                     >
-                      {r.era}
+                      {r.teamType === "curr" ? "CURRENT" : r.teamType === "class" ? "CLASSIC" : "ALL-TIME"}
                     </span>
-                    <OvrChip ovr={r.ovr} size="sm" />
+                    <OvrChip ovr={r.overall} size="sm" />
                     <span
                       className="rounded-[5px] bg-[#faf7ee] py-[3px] text-center text-[12.5px] font-bold tabular-nums"
-                      style={{ color: getAttributeColor(r.tpt) }}
+                      style={{ color: getAttributeColor(r.threePointShot ?? 0) }}
                     >
-                      {r.tpt}
+                      {r.threePointShot ?? "—"}
                     </span>
                   </Link>
                 ))}
@@ -415,8 +465,7 @@ export default function Home() {
             </div>
             <div className="flex flex-wrap items-center justify-between gap-2 bg-[#faf9f5] px-5 py-[9px]">
               <span className="font-plex text-[8.5px] text-[#b5b0a1]">
-                <b className="text-[#1a1918]">247 MATCH</b> · SHOWING 6 · CURRENT + CLASSIC IN ONE
-                CALL
+                <b className="text-[#1a1918]">{demoResults.length} MATCH</b> · SHOWING {Math.min(6, demoResults.length)} · LIVE {CURRENT_GAME_VERSION} DATA
               </span>
               <span className="font-plex text-[8.5px] text-[#b5b0a1]">● = QUERIED COLUMN</span>
             </div>

--- a/app/players/[slug]/page.tsx
+++ b/app/players/[slug]/page.tsx
@@ -220,9 +220,11 @@ function PlayerDossier() {
   const radar = useMemo(() => {
     if (!dossier || !player) return null;
     const byKey = Object.fromEntries(dossier.categories.map((c) => [c.key, c.score]));
+    const avgByKey = Object.fromEntries(dossier.categories.map((c) => [c.key, c.avg]));
     const axes = RADAR_AXES.map((a) => ({
       ...a,
       value: a.key === "overall" ? player.overall : (byKey[a.key] as number | null),
+      average: a.key === "overall" ? dossier.overallAvg : (avgByKey[a.key] as number | null),
     }));
     const cx = 105;
     const cy = 92;
@@ -239,6 +241,8 @@ function PlayerDossier() {
     );
     const dots = axes.map((a, i) => pt(i, ((a.value ?? 0) / 99) * r));
     const path = dots.map((p, i) => `${i === 0 ? "M" : "L"} ${p.x} ${p.y}`).join(" ") + " Z";
+    const avgDots = axes.map((a, i) => pt(i, ((a.average ?? 0) / 99) * r));
+    const avgPath = avgDots.map((p, i) => `${i === 0 ? "M" : "L"} ${p.x} ${p.y}`).join(" ") + " Z";
     const ticks = axes.map((a, i) => {
       const p = pt(i, r + 14);
       const dx = p.x - cx;
@@ -250,7 +254,7 @@ function PlayerDossier() {
         anchor: (Math.abs(dx) < 8 ? "middle" : dx > 0 ? "start" : "end") as "middle" | "start" | "end",
       };
     });
-    return { rings, dots, path, ticks };
+    return { rings, dots, path, avgPath, ticks };
   }, [dossier, player]);
 
   const badgeShelf = useMemo(() => {
@@ -344,7 +348,7 @@ function PlayerDossier() {
         </div>
 
         {/* Tier card + right column */}
-        <div className="mt-[18px] grid grid-cols-[repeat(auto-fit,minmax(min(100%,320px),1fr))] items-stretch gap-[22px]">
+        <div className="mt-[18px] grid items-stretch gap-[22px] lg:grid-cols-[minmax(320px,420px)_minmax(0,1fr)]">
           {/* MyTeam tier card */}
           <div className="flex max-w-[420px] flex-col gap-2.5">
           <div
@@ -632,13 +636,20 @@ function PlayerDossier() {
 
           {/* Category radar */}
           <div className="rounded-[14px] border border-[#e5e2da] bg-white px-[18px] py-3.5">
-            <div className={cn(CARD_LABEL, "mb-1")}>CATEGORY RADAR</div>
+            <div className="mb-1 flex items-center justify-between gap-3">
+              <div className={CARD_LABEL}>CATEGORY RADAR</div>
+              <div className="flex items-center gap-3 font-plex text-[7.5px] text-[#8a8577]">
+                <span className="inline-flex items-center gap-1"><i className="h-0.5 w-3 bg-[#1a1918]" />PLAYER</span>
+                <span className="inline-flex items-center gap-1"><i className="h-0.5 w-3 border-t border-dashed border-[#b98404]" />{dossier?.primaryPosition ?? "POS"} AVG</span>
+              </div>
+            </div>
             <div className="flex justify-center">
               {radar ? (
                 <svg width="210" height="184" viewBox="0 0 210 184" className="overflow-visible">
                   {radar.rings.map((ring) => (
                     <polygon key={ring} points={ring} fill="none" stroke="#e5e2da" strokeWidth="1" />
                   ))}
+                  <path d={radar.avgPath} fill="#d3a21d" fillOpacity="0.06" stroke="#b98404" strokeWidth="1.5" strokeDasharray="4 4" />
                   <path d={radar.path} fill="#1a1918" fillOpacity="0.08" stroke="#1a1918" strokeWidth="2" />
                   {radar.dots.map((d, i) => (
                     <circle key={i} cx={d.x} cy={d.y} r="2.5" fill="#1a1918" />

--- a/app/players/[slug]/page.tsx
+++ b/app/players/[slug]/page.tsx
@@ -260,7 +260,8 @@ function PlayerDossier() {
   const badgeShelf = useMemo(() => {
     if (!dossier) return [];
     const byTier = new Map<string, (typeof dossier.badges)[number][]>();
-    for (const b of dossier.badges) {
+    const uniqueBadges = [...new Map(dossier.badges.map((b) => [`${b.slug}:${b.tier}`, b])).values()];
+    for (const b of uniqueBadges) {
       if (!byTier.has(b.tier)) byTier.set(b.tier, []);
       byTier.get(b.tier)!.push(b);
     }

--- a/convex/badges.ts
+++ b/convex/badges.ts
@@ -344,7 +344,7 @@ export const syncBadgesFromPlayers = internalMutation({
 
     const seenBadges = new Map<
       string,
-      { name: string; category: string; imageUrl?: string }
+      { name: string; category: string; description?: string; imageUrl?: string }
     >();
 
     // Collect unique badges from all players
@@ -353,10 +353,13 @@ export const syncBadgesFromPlayers = internalMutation({
       for (const badge of badgeList) {
         const slug = slugify(badge.name);
         if (!seenBadges.has(slug)) {
-          seenBadges.set(slug, {
+          const badgeRecord: { name: string; category: string; description?: string; imageUrl?: string } = {
             name: badge.name,
             category: badge.category || "Unknown",
-          });
+          };
+          if (badge.description) badgeRecord.description = badge.description;
+          if (badge.imageUrl) badgeRecord.imageUrl = badge.imageUrl;
+          seenBadges.set(slug, badgeRecord);
         }
       }
     }
@@ -374,18 +377,24 @@ export const syncBadgesFromPlayers = internalMutation({
       if (existing) {
         await ctx.db.patch(existing._id, {
           category: badge.category,
+          description: badge.description ?? existing.description,
+          imageUrl: badge.imageUrl ?? existing.imageUrl,
+          gameVersion: CURRENT_GAME_VERSION,
           lastUpdated: now,
         });
         updated++;
       } else {
-        await ctx.db.insert("badges", {
+        const newBadge = {
           name: badge.name,
           slug,
           category: badge.category,
           gameVersion: CURRENT_GAME_VERSION,
           lastUpdated: now,
           createdAt: now,
-        });
+          ...(badge.description ? { description: badge.description } : {}),
+          ...(badge.imageUrl ? { imageUrl: badge.imageUrl } : {}),
+        };
+        await ctx.db.insert("badges", newBadge);
         inserted++;
       }
     }

--- a/convex/dossier.ts
+++ b/convex/dossier.ts
@@ -119,9 +119,13 @@ export const getDossier = query({
       return {
         key: cat,
         score: score === null ? null : Math.round(score),
+        avg: values.length === 0 ? null : Math.round(values.reduce((sum, n) => sum + n, 0) / values.length),
         pct: score === null ? null : percentile(values, score),
       };
     });
+    const overallAvg = cohort.length
+      ? Math.round(cohort.reduce((sum, p) => sum + p.overall, 0) / cohort.length)
+      : null;
     const overallPct = percentile(
       cohort.map((p) => p.overall),
       player.overall
@@ -175,7 +179,7 @@ export const getDossier = query({
       .withIndex("by_playerId", (q) => q.eq("playerId", player._id))
       .collect();
     const badgeDocs = await Promise.all(badgeLinks.map((l) => ctx.db.get(l.badgeId)));
-    const badges = badgeLinks
+    const normalizedBadges = badgeLinks
       .map((l, i) => {
         const b = badgeDocs[i];
         return b
@@ -189,6 +193,19 @@ export const getDossier = query({
           : null;
       })
       .filter((b): b is NonNullable<typeof b> => b !== null);
+    // The scraper's source of truth is the embedded badge list on each player.
+    // Use it immediately when the normalized badge index has not been rebuilt
+    // yet, so the dossier never lies with "0 badges" after a fresh scrape.
+    const rawBadges = normalizedBadges.length
+      ? normalizedBadges
+      : (player.badges?.list ?? []).map((b) => ({
+          name: b.name,
+          slug: b.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, ""),
+          tier: b.tier,
+          imageUrl: b.imageUrl ?? null,
+          description: b.description ?? null,
+        }));
+    const badges = [...new Map(rawBadges.map((b) => [`${b.slug}:${b.tier}`, b])).values()];
 
     return {
       player: {
@@ -213,6 +230,7 @@ export const getDossier = query({
       attrStats,
       categories,
       overallPct,
+      overallAvg,
       similar,
       history,
       seasonMovement,

--- a/convex/players.ts
+++ b/convex/players.ts
@@ -878,6 +878,11 @@ export const getPlaygroundPlayers = query({
       positions: p.positions ?? [],
       overall: p.overall,
       playerImage: p.playerImage ?? null,
+      attributes: p.attributes ?? {},
+      badges: (p.badges?.list ?? []).map((badge) => ({
+        name: badge.name,
+        tier: badge.tier,
+      })),
       threePointShot: p.attributes?.threePointShot ?? null,
       speed: p.attributes?.speed ?? null,
       drivingDunk: p.attributes?.drivingDunk ?? null,


### PR DESCRIPTION
## Summary
- replace the fictional landing-page playground mock with a controlled live-data demo
- restore the original compact one-screen workbench: persistent player pool left, court + analysis right
- keep drag-and-drop first-class; single mode leaves the opponent half inactive, matchup mode enables it without reshaping the workspace
- move advanced controls behind a focused Filter button while search + quick position filters stay in the pool
- add player filters for position, era, card tier, OVR range, specific attribute threshold, badge name, and badge tier
- add an explainable single-lineup report: identity, offense/defense/fit/versatility grades, role coverage, durable strengths, failure modes, and one next move
- hydrate selected lineup analysis through the already-deployed full-player query so Vercel previews never interpret rollout-missing fields as zero
- tighten the dossier desktop grid and layer position averages under the category radar
- make dossier badges fall back to the scraper's embedded source and dedupe stale normalized links
- preserve badge descriptions and images when rebuilding the normalized badge index

## Verification
- `npx tsc --noEmit`
- `npm run build`
- `npx convex dev --once`
- rendered browser pass: landing controls update query URL/results; compact pool/court/analysis fit together at desktop viewport; Michael Jordan drag from permanent pool to court updates lineup URL; advanced filter dialog opens over the workspace; complete five produces a scannable report with four grades + five coverage checks + evidence/risks/next move; dossier shows 26 deduped Shai badges and PG-average radar legend
- latest Vercel preview verified against production Convex: Magic/Kobe/Bird/Hakeem/Kareem produced B+ offense, A defense, A+ fit/versatility and nonzero role coverage (no false D/zero state)
- production data audit: Shai's embedded player record contains 26 named badges with tiers, descriptions, and image URLs

## Post-merge operation
After the production Convex deploy completes, run:

```sh
npx convex run --prod badges:syncBadgesFromPlayers
npx convex run --prod badges:linkPlayerBadgesFromData
```

This rebuilds the standalone badge index from the already-correct embedded player badge payloads.
