### PR TITLE
Add community showcase for projects built on the API

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import { api } from "../convex/_generated/api";
 import { TopNav } from "@/components/chrome/top-nav";
 import { SiteFooter } from "@/components/chrome/site-footer";
 import { KeyDialog } from "@/components/chrome/key-dialog";
+import { ShowcaseStrip } from "@/components/showcase/showcase-strip";
 import { getRatingClasses, getRatingTier, getAttributeColor } from "@/lib/rating-colors";
 import { getTeamAbbreviation } from "@/lib/team-abbr";
 import { API_KEY_STORAGE_KEY } from "@/lib/constants";
@@ -173,6 +174,9 @@ export default function Home() {
   const teaserUrl = `/api/players?position=${DEMO_POSITIONS[demoPosition].value}&era=${DEMO_ERAS[demoEra].value}&three_ball_gte=${DEMO_THRESHOLDS[demoThreshold]}&sort=${DEMO_SORTS[demoSort].value}:desc`;
 
   useEffect(() => {
+    // API key lives in localStorage, so it must be read on the client after
+    // mount to avoid an SSR/hydration mismatch.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setHasApiKey(!!localStorage.getItem(API_KEY_STORAGE_KEY));
   }, []);
 
@@ -652,6 +656,9 @@ export default function Home() {
             </div>
           </div>
         </div>
+
+        {/* Showcase — community projects built on the API (hidden until seeded) */}
+        <ShowcaseStrip />
 
         {/* CTA */}
         <div

--- a/app/showcase/page.tsx
+++ b/app/showcase/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { TopNav } from "@/components/chrome/top-nav";
+import { FooterStrip } from "@/components/chrome/footer-strip";
+import { ShowcaseCard } from "@/components/showcase/showcase-card";
+import { SubmitProjectDialog } from "@/components/showcase/submit-project-dialog";
+
+export default function ShowcasePage() {
+  const projects = useQuery(api.showcase.getApprovedProjects, {});
+
+  return (
+    <div className="min-h-screen bg-[linear-gradient(to_bottom,#fffdf8,#faf9f5_420px)] font-body text-[#1a1918]">
+      <TopNav />
+
+      <main className="mx-auto max-w-[1360px] px-[clamp(20px,4vw,48px)] pt-2 pb-16">
+        {/* Header */}
+        <div className="pt-8 pb-9">
+          <div className="mb-3 font-plex text-[11px] tracking-[0.12em] text-[#8a8577]">
+            SHOWCASE
+          </div>
+          <h1 className="font-display text-[clamp(32px,5vw,44px)] font-extrabold leading-[1.05] tracking-[-0.02em] text-[#1a1918]">
+            Built with nba2kapi
+          </h1>
+          <p className="mt-3.5 max-w-[560px] text-[15px] leading-[1.6] text-[#57534a]">
+            Apps, bots, league tools, and experiments built on the API. Made something? Add it.
+          </p>
+          <div className="mt-6">
+            <SubmitProjectDialog />
+          </div>
+        </div>
+
+        {/* Grid */}
+        {projects === undefined ? (
+          <div className="py-16 text-center text-[14px] text-[#8a8577]">Loading...</div>
+        ) : projects.length === 0 ? (
+          <div className="rounded-2xl border border-[#e5e2da] bg-white py-16 text-center text-[14px] text-[#8a8577]">
+            Nothing here yet. Be the first to add a project.
+          </div>
+        ) : (
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-5">
+            {projects.map((p) => (
+              <ShowcaseCard key={p._id} project={p} />
+            ))}
+          </div>
+        )}
+      </main>
+
+      <FooterStrip />
+    </div>
+  );
+}

--- a/components/chrome/site-footer.tsx
+++ b/components/chrome/site-footer.tsx
@@ -46,6 +46,9 @@ export function SiteFooter() {
               <Link href="/playground" className={FOOTER_LINK}>
                 Player dossiers
               </Link>
+              <Link href="/showcase" className={FOOTER_LINK}>
+                Showcase
+              </Link>
             </div>
           </div>
 

--- a/components/showcase/showcase-card.tsx
+++ b/components/showcase/showcase-card.tsx
@@ -1,0 +1,85 @@
+import Image from "next/image";
+import { ArrowUpRight } from "lucide-react";
+
+export type ShowcaseProject = {
+  _id: string;
+  name: string;
+  url: string;
+  description: string;
+  category: string;
+  featured: boolean;
+  createdAt: string;
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  app: "App",
+  "league-tool": "League tool",
+  bot: "Bot",
+  "data-viz": "Data viz",
+  other: "Other",
+};
+
+// Live screenshot of the project URL via microlink (already whitelisted in
+// next.config). Rendered unoptimized: it is generated on demand, so the Next
+// image optimizer would only add latency.
+function screenshotUrl(url: string) {
+  const params = new URLSearchParams({
+    url,
+    screenshot: "true",
+    meta: "false",
+    embed: "screenshot.url",
+    colorScheme: "light",
+    "viewport.width": "1280",
+    "viewport.height": "800",
+    "viewport.deviceScaleFactor": "1",
+  });
+  return `https://api.microlink.io/?${params.toString()}`;
+}
+
+function hostname(url: string) {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+export function ShowcaseCard({ project }: { project: ShowcaseProject }) {
+  const label = CATEGORY_LABELS[project.category] ?? "Project";
+  return (
+    <a
+      href={project.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex flex-col overflow-hidden rounded-2xl border border-[#e5e2da] bg-white no-underline transition-[border-color,transform] duration-150 ease-out hover:-translate-y-0.5 hover:border-[#d8d4c8] motion-reduce:transform-none"
+    >
+      <div className="relative aspect-[16/10] w-full overflow-hidden bg-[#f1efe8]">
+        <Image
+          src={screenshotUrl(project.url)}
+          alt={`${project.name} screenshot`}
+          fill
+          unoptimized
+          sizes="(max-width: 768px) 100vw, 400px"
+          className="object-cover object-top"
+        />
+      </div>
+      <div className="flex flex-1 flex-col p-5">
+        <div className="mb-2">
+          <span className="inline-flex items-center rounded-full border border-[#e5e2da] bg-[#faf9f5] px-2.5 py-1 text-[11px] font-medium text-[#57534a]">
+            {label}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <h3 className="font-display text-[17px] font-bold tracking-[-0.01em] text-[#1a1918]">
+            {project.name}
+          </h3>
+          <ArrowUpRight className="h-4 w-4 text-[#8a8577] transition-colors duration-150 group-hover:text-[#1a1918]" />
+        </div>
+        <p className="mt-1.5 flex-1 text-[13.5px] leading-[1.55] text-[#57534a]">
+          {project.description}
+        </p>
+        <div className="mt-3 font-plex text-[11px] text-[#b5b0a1]">{hostname(project.url)}</div>
+      </div>
+    </a>
+  );
+}

--- a/components/showcase/showcase-strip.tsx
+++ b/components/showcase/showcase-strip.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { ShowcaseCard } from "./showcase-card";
+
+/**
+ * Landing-page band that previews a few approved projects and links to the
+ * full /showcase page. Renders nothing until at least one project is approved,
+ * so the landing is never a wall of empty state.
+ */
+export function ShowcaseStrip() {
+  const projects = useQuery(api.showcase.getApprovedProjects, { limit: 3 });
+
+  if (!projects || projects.length === 0) return null;
+
+  return (
+    <div className="border-t border-[#e5e2da] px-[clamp(20px,4vw,48px)] py-[clamp(56px,7vw,96px)]">
+      <div className="mx-auto max-w-[1360px]">
+        <div className="mb-9 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <div className="mb-3 font-plex text-[11px] tracking-[0.12em] text-[#8a8577]">
+              BUILT WITH NBA2KAPI
+            </div>
+            <h2 className="mt-0 mb-0 font-display text-[clamp(28px,3.4vw,42px)] font-bold tracking-[-0.02em] text-[#1a1918]">
+              Made by the community
+            </h2>
+          </div>
+          <Link
+            href="/showcase"
+            className="rounded-full border border-[#d9d4c7] bg-white px-5 py-2.5 text-[13.5px] font-semibold text-[#1a1918] no-underline transition-[background,transform] duration-150 ease-out hover:bg-[#f1efe8] active:scale-[0.97] motion-reduce:transition-none"
+          >
+            See all →
+          </Link>
+        </div>
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-5">
+          {projects.map((p) => (
+            <ShowcaseCard key={p._id} project={p} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/showcase/submit-project-dialog.tsx
+++ b/components/showcase/submit-project-dialog.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Plus, CheckCircle2 } from "lucide-react";
+
+const CATEGORIES = [
+  { value: "app", label: "App" },
+  { value: "league-tool", label: "League tool" },
+  { value: "bot", label: "Bot" },
+  { value: "data-viz", label: "Data viz" },
+  { value: "other", label: "Other" },
+];
+
+const INPUT_CLASS =
+  "flex w-full rounded-lg border border-[#e5e2da] bg-white px-3 py-2 text-[14px] text-[#1a1918] placeholder:text-[#b5b0a1] focus-visible:outline-none focus-visible:border-[#1a1918] disabled:cursor-not-allowed disabled:opacity-50";
+
+const LABEL_CLASS = "text-[12px] font-medium text-[#57534a]";
+
+export function SubmitProjectDialog() {
+  const [open, setOpen] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [name, setName] = useState("");
+  const [url, setUrl] = useState("");
+  const [description, setDescription] = useState("");
+  const [category, setCategory] = useState("app");
+  const [submitterName, setSubmitterName] = useState("");
+  const [submitterEmail, setSubmitterEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submitProject = useMutation(api.showcase.submitProject);
+
+  const reset = () => {
+    setName("");
+    setUrl("");
+    setDescription("");
+    setCategory("app");
+    setSubmitterName("");
+    setSubmitterEmail("");
+    setError(null);
+    setSubmitted(false);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) setTimeout(reset, 200);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !url.trim() || !description.trim()) return;
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await submitProject({
+        name,
+        url,
+        description,
+        category,
+        submitterName: submitterName || undefined,
+        submitterEmail: submitterEmail || undefined,
+      });
+      setSubmitted(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong. Please try again.");
+    }
+    setIsSubmitting(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex cursor-pointer items-center gap-2 rounded-full bg-[#1a1918] px-5 py-2.5 text-[13.5px] font-semibold text-[#faf9f5] no-underline transition-[background,transform] duration-150 ease-out hover:bg-[#333] active:scale-[0.97] motion-reduce:transition-none"
+        >
+          <Plus className="h-4 w-4" />
+          Submit a project
+        </button>
+      </DialogTrigger>
+      <DialogContent className="border-[#e5e2da] bg-[#faf9f5] text-[#1a1918] sm:max-w-lg">
+        {submitted ? (
+          <div className="flex flex-col items-center py-8 text-center">
+            <CheckCircle2 className="h-10 w-10 text-[#0a7f3f]" strokeWidth={1.75} />
+            <h2 className="mt-4 font-display text-[20px] font-extrabold tracking-[-0.01em] text-[#1a1918]">
+              Thanks, it’s in the queue
+            </h2>
+            <p className="mt-2 max-w-[340px] text-[13.5px] leading-[1.55] text-[#57534a]">
+              We review each submission before it goes live, so your project will show up on the
+              showcase once it’s approved.
+            </p>
+            <button
+              type="button"
+              onClick={() => handleOpenChange(false)}
+              className="mt-6 inline-flex cursor-pointer items-center justify-center rounded-full bg-[#1a1918] px-5 py-2 text-[13.5px] font-semibold text-[#faf9f5] transition-[background,transform] duration-150 ease-out hover:bg-[#333] active:scale-[0.97] motion-reduce:transition-none"
+            >
+              Done
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <DialogHeader>
+              <DialogTitle className="font-display text-[19px] font-extrabold tracking-[-0.01em] text-[#1a1918]">
+                Submit a project
+              </DialogTitle>
+              <DialogDescription className="text-[13.5px] text-[#8a8577]">
+                Built something on nba2kapi? Share it and we’ll feature it after a quick review.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <div className="space-y-2">
+                <div className={LABEL_CLASS}>Category</div>
+                <div className="flex flex-wrap gap-2">
+                  {CATEGORIES.map((t) => {
+                    const selected = category === t.value;
+                    return (
+                      <button
+                        key={t.value}
+                        type="button"
+                        onClick={() => setCategory(t.value)}
+                        className={
+                          selected
+                            ? "inline-flex cursor-pointer items-center rounded-full border border-[#1a1918] bg-[#1a1918] px-3 py-1.5 text-[12.5px] font-medium text-[#faf9f5] transition-colors duration-150"
+                            : "inline-flex cursor-pointer items-center rounded-full border border-[#e5e2da] bg-white px-3 py-1.5 text-[12.5px] font-medium text-[#57534a] transition-colors duration-150 hover:border-[#1a1918]"
+                        }
+                      >
+                        {t.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="sc-name" className={LABEL_CLASS}>
+                  Project name <span className="text-[#b5b0a1]">({name.length}/60)</span>
+                </label>
+                <input
+                  id="sc-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value.slice(0, 60))}
+                  placeholder="Blacktop Blitz"
+                  className={INPUT_CLASS}
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="sc-url" className={LABEL_CLASS}>
+                  URL
+                </label>
+                <input
+                  id="sc-url"
+                  type="url"
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value.slice(0, 300))}
+                  placeholder="https://yourproject.com"
+                  className={INPUT_CLASS}
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="sc-desc" className={LABEL_CLASS}>
+                  Description <span className="text-[#b5b0a1]">({description.length}/240)</span>
+                </label>
+                <textarea
+                  id="sc-desc"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value.slice(0, 240))}
+                  placeholder="One line on what it does and how it uses the API."
+                  rows={3}
+                  className={INPUT_CLASS + " resize-none"}
+                  required
+                />
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <label htmlFor="sc-author" className={LABEL_CLASS}>
+                    Your name <span className="text-[#b5b0a1]">(optional)</span>
+                  </label>
+                  <input
+                    id="sc-author"
+                    value={submitterName}
+                    onChange={(e) => setSubmitterName(e.target.value.slice(0, 60))}
+                    placeholder="Anonymous"
+                    className={INPUT_CLASS}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label htmlFor="sc-email" className={LABEL_CLASS}>
+                    Email <span className="text-[#b5b0a1]">(optional, private)</span>
+                  </label>
+                  <input
+                    id="sc-email"
+                    type="email"
+                    value={submitterEmail}
+                    onChange={(e) => setSubmitterEmail(e.target.value.slice(0, 120))}
+                    placeholder="you@email.com"
+                    className={INPUT_CLASS}
+                  />
+                </div>
+              </div>
+
+              {error && <p className="text-[13px] text-[#c2410c]">{error}</p>}
+            </div>
+            <DialogFooter>
+              <button
+                type="button"
+                onClick={() => handleOpenChange(false)}
+                className="inline-flex cursor-pointer items-center justify-center rounded-full border border-[#e5e2da] bg-white px-4 py-2 text-[13.5px] font-medium text-[#57534a] transition-colors duration-150 hover:border-[#1a1918]"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={isSubmitting || !name.trim() || !url.trim() || !description.trim()}
+                className="inline-flex cursor-pointer items-center justify-center rounded-full bg-[#1a1918] px-5 py-2 text-[13.5px] font-semibold text-[#faf9f5] transition-[background,transform] duration-150 ease-out hover:bg-[#333] active:scale-[0.97] disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transition-none"
+              >
+                {isSubmitting ? "Submitting..." : "Submit"}
+              </button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import { HonoWithConvex, HttpRouterWithHono } from "convex-helpers/server/hono";
 import { ActionCtx } from "./_generated/server";
-import { api } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import { Id } from "./_generated/dataModel";
 import { CURRENT_GAME_VERSION } from "./gameVersion";
 import {
@@ -606,6 +606,57 @@ app.get("/api/admin/stats", async (c) => {
     ), 500);
   }
 });
+
+// GET /api/admin/showcase - List pending showcase submissions (requires admin key)
+app.get("/api/admin/showcase", async (c) => {
+  const auth = validateAdminKey(c);
+  if (!auth.valid) return auth.error;
+
+  try {
+    const pending = await c.env.runQuery(internal.showcase.listPending, {});
+    c.header("Cache-Control", "no-store");
+    return c.json(successResponse(pending, { count: pending.length }));
+  } catch (error: any) {
+    console.error("List pending showcase error:", error);
+    return c.json(errorResponse(
+      "Failed to list showcase submissions",
+      "QUERY_ERROR"
+    ), 500);
+  }
+});
+
+// POST /api/admin/showcase/:id - Approve/reject a submission (requires admin key)
+// Body: { status: "approved" | "rejected" | "pending", featured?: boolean }
+app.post("/api/admin/showcase/:id",
+  zValidator("json", z.object({
+    status: z.enum(["approved", "rejected", "pending"]),
+    featured: z.boolean().optional(),
+  })),
+  async (c) => {
+    const auth = validateAdminKey(c);
+    if (!auth.valid) return auth.error;
+
+    try {
+      const id = c.req.param("id") as Id<"showcaseProjects">;
+      const body = c.req.valid("json");
+      const mutationArgs: {
+        id: Id<"showcaseProjects">;
+        status: "approved" | "rejected" | "pending";
+        featured?: boolean;
+      } = { id, status: body.status };
+      if (body.featured !== undefined) mutationArgs.featured = body.featured;
+      await c.env.runMutation(internal.showcase.setStatus, mutationArgs);
+      c.header("Cache-Control", "no-store");
+      return c.json(successResponse({ id, ...body }));
+    } catch (error: any) {
+      console.error("Update showcase status error:", error);
+      return c.json(errorResponse(
+        "Failed to update submission",
+        "MUTATION_ERROR"
+      ), 500);
+    }
+  }
+);
 
 // GET /api/admin/scrape/jobs - Get recent scrape jobs (requires admin key in header)
 app.get("/api/admin/scrape/jobs",

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -347,4 +347,25 @@ export default defineSchema({
     date: v.string(),
     visitorId: v.string(),
   }).index("by_date_and_visitor", ["date", "visitorId"]),
+
+  /**
+   * Showcase - community-submitted apps and projects built on the API.
+   * Submissions start "pending" and only render publicly once "approved"
+   * (moderation gate, see convex/showcase.ts). submitterEmail is private and
+   * is never returned by the public query; it is kept for contact/verification.
+   */
+  showcaseProjects: defineTable({
+    name: v.string(),
+    url: v.string(),
+    description: v.string(),
+    category: v.string(), // "app" | "league-tool" | "bot" | "data-viz" | "other"
+    status: v.string(), // "pending" | "approved" | "rejected"
+    featured: v.optional(v.boolean()), // surfaced in the landing strip
+    submitterName: v.optional(v.string()),
+    submitterEmail: v.optional(v.string()), // private, never exposed publicly
+    createdAt: v.string(),
+    approvedAt: v.optional(v.string()),
+  })
+    .index("by_status", ["status"])
+    .index("by_status_and_createdAt", ["status", "createdAt"]),
 });

--- a/convex/showcase.ts
+++ b/convex/showcase.ts
@@ -1,0 +1,188 @@
+import { mutation, query, internalMutation, internalQuery } from "./_generated/server";
+import { v } from "convex/values";
+import type { Doc } from "./_generated/dataModel";
+
+const CATEGORIES = ["app", "league-tool", "bot", "data-viz", "other"];
+
+// Fields safe to expose publicly. submitterEmail is deliberately excluded.
+function toPublic(p: Doc<"showcaseProjects">) {
+  return {
+    _id: p._id,
+    name: p.name,
+    url: p.url,
+    description: p.description,
+    category: p.category,
+    featured: p.featured ?? false,
+    createdAt: p.createdAt,
+  };
+}
+
+/**
+ * Public: approved projects only, featured first then newest.
+ * Never returns submitter contact info.
+ */
+export const getApprovedProjects = query({
+  args: {
+    limit: v.optional(v.number()),
+    featuredOnly: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const approved = await ctx.db
+      .query("showcaseProjects")
+      .withIndex("by_status", (q) => q.eq("status", "approved"))
+      .collect();
+
+    let projects = approved;
+    if (args.featuredOnly) {
+      projects = projects.filter((p) => p.featured);
+    }
+
+    projects.sort((a, b) => {
+      const af = a.featured ? 1 : 0;
+      const bf = b.featured ? 1 : 0;
+      if (bf !== af) return bf - af;
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    });
+
+    if (args.limit !== undefined) {
+      projects = projects.slice(0, args.limit);
+    }
+
+    return projects.map(toPublic);
+  },
+});
+
+/**
+ * Public: submit a project. Starts as "pending" and is invisible on the site
+ * until an admin approves it (see the /api/admin/showcase endpoints).
+ */
+export const submitProject = mutation({
+  args: {
+    name: v.string(),
+    url: v.string(),
+    description: v.string(),
+    category: v.string(),
+    submitterName: v.optional(v.string()),
+    submitterEmail: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const name = args.name.trim();
+    const url = args.url.trim();
+    const description = args.description.trim();
+
+    if (!name || name.length > 60) {
+      throw new Error("Name must be 1-60 characters");
+    }
+    if (!/^https?:\/\/.+\..+/.test(url) || url.length > 300) {
+      throw new Error("URL must be a valid http(s) link");
+    }
+    if (!description || description.length > 240) {
+      throw new Error("Description must be 1-240 characters");
+    }
+    if (!CATEGORIES.includes(args.category)) {
+      throw new Error("Invalid category");
+    }
+
+    const data: {
+      name: string;
+      url: string;
+      description: string;
+      category: string;
+      status: string;
+      featured: boolean;
+      createdAt: string;
+      submitterName?: string;
+      submitterEmail?: string;
+    } = {
+      name,
+      url,
+      description,
+      category: args.category,
+      status: "pending",
+      featured: false,
+      createdAt: new Date().toISOString(),
+    };
+
+    if (args.submitterName?.trim()) data.submitterName = args.submitterName.trim();
+    if (args.submitterEmail?.trim()) data.submitterEmail = args.submitterEmail.trim();
+
+    await ctx.db.insert("showcaseProjects", data);
+
+    return { success: true };
+  },
+});
+
+/**
+ * Admin (internal): list pending submissions for review, including submitter
+ * contact info. Reached through the admin-key-gated HTTP endpoint.
+ */
+export const listPending = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const pending = await ctx.db
+      .query("showcaseProjects")
+      .withIndex("by_status", (q) => q.eq("status", "pending"))
+      .collect();
+    return pending.sort(
+      (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+    );
+  },
+});
+
+/**
+ * Admin (internal): approve or reject a submission, and optionally toggle the
+ * landing-strip feature flag.
+ */
+export const setStatus = internalMutation({
+  args: {
+    id: v.id("showcaseProjects"),
+    status: v.union(v.literal("approved"), v.literal("rejected"), v.literal("pending")),
+    featured: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const project = await ctx.db.get(args.id);
+    if (!project) throw new Error("Project not found");
+
+    const patch: { status: string; approvedAt?: string; featured?: boolean } = {
+      status: args.status,
+    };
+    if (args.status === "approved" && !project.approvedAt) {
+      patch.approvedAt = new Date().toISOString();
+    }
+    if (args.featured !== undefined) {
+      patch.featured = args.featured;
+    }
+
+    await ctx.db.patch(args.id, patch);
+    return { success: true };
+  },
+});
+
+/**
+ * Admin (internal): idempotent seed for the first showcase entry
+ * (blacktopblitz.com). Safe to run more than once.
+ */
+export const seedShowcase = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const url = "https://blacktopblitz.com";
+    const existing = await ctx.db
+      .query("showcaseProjects")
+      .collect()
+      .then((all) => all.find((p) => p.url === url));
+    if (existing) return { seeded: false, id: existing._id };
+
+    const id = await ctx.db.insert("showcaseProjects", {
+      name: "Blacktop Blitz",
+      url,
+      description:
+        "A random team generator for NBA 2K's Blacktop mode, pulling live player ratings and rosters from nba2kapi.",
+      category: "app",
+      status: "approved",
+      featured: true,
+      createdAt: new Date().toISOString(),
+      approvedAt: new Date().toISOString(),
+    });
+    return { seeded: true, id };
+  },
+});


### PR DESCRIPTION
## What

A **"Built with nba2kapi" showcase**: a self-serve gallery where people submit apps and projects they've built on the API, so others can discover them. Moderated (you approve before anything goes live). Seeded with **Blacktop Blitz**.

Per the decision: not in the top nav. It surfaces as a **band on the landing page** ("Made by the community") that links to a dedicated **`/showcase`** page, plus a footer link.

## How it works

- **Submit** (self-serve): anyone fills the editorial submit dialog. Entries start `pending` and are **invisible** on the site until approved. `submitterEmail` is optional, private, and never returned by the public query.
- **Approve** (you): admin-key-gated endpoints, mirroring the existing `/api/admin/*` pattern:
  - `GET /api/admin/showcase` — the pending queue (includes submitter contact for review)
  - `POST /api/admin/showcase/:id` with `{ "status": "approved" | "rejected", "featured"?: true }`
- **Cards** auto-render a live screenshot of each project's URL via your existing microlink `link-preview` setup. No image uploads, no asset storage.
- The landing band renders **nothing** until at least one project is approved, so the landing is never an empty state.

## Files

- `convex/schema.ts` — new `showcaseProjects` table (status/featured indexes)
- `convex/showcase.ts` — `submitProject`, `getApprovedProjects` (public), `listPending`, `setStatus`, `seedShowcase` (internal)
- `convex/http.ts` — the two admin endpoints
- `app/showcase/page.tsx`, `components/showcase/*` — page, card, landing strip, submit dialog
- `app/page.tsx`, `components/chrome/site-footer.tsx` — landing band + footer link

## Verified

- `tsc` clean; `convex codegen` stricter typecheck clean; eslint clean on changed files.
- Seeded Blacktop Blitz on dev and rendered `/showcase` and the landing band live: card, auto-screenshot (loaded), submit button, footer link all working.

## Note on seeding prod

Blacktop Blitz is seeded on the dev deployment for verification. To seed it on prod after this merges + deploys, run `npx convex run showcase:seedShowcase --prod` (idempotent). I did not write to prod from this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)