### PR TITLE
fix: make admin-gated Convex queries internal to close public bypass

### DIFF
--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -6,12 +6,16 @@
  * the HTTP layer; this file just exposes the raw Convex query.
  */
 
-import { query } from "./_generated/server";
+import { internalQuery } from "./_generated/server";
 
 const MS_PER_HOUR = 60 * 60 * 1000;
 const MS_PER_DAY = 24 * MS_PER_HOUR;
 
-export const getAdminStats = query({
+// internalQuery, not query: this returns every API-key holder's email plus the
+// full usage/top-users breakdown. The X-Admin-Key gate lives in the HTTP layer
+// (convex/http.ts). A public `query` would be callable directly from any browser
+// via NEXT_PUBLIC_CONVEX_URL, bypassing that gate entirely.
+export const getAdminStats = internalQuery({
   args: {},
   handler: async (ctx) => {
     const now = Date.now();

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -594,7 +594,7 @@ app.get("/api/admin/stats", async (c) => {
   if (!auth.valid) return auth.error;
 
   try {
-    const stats = await c.env.runQuery(api.admin.getAdminStats, {});
+    const stats = await c.env.runQuery(internal.admin.getAdminStats, {});
     // No caching — stats should reflect current state on every call.
     c.header("Cache-Control", "no-store");
     return c.json(successResponse(stats));
@@ -671,7 +671,7 @@ app.get("/api/admin/scrape/jobs",
     try {
       const { limit } = c.req.valid("query");
 
-      const jobs = await c.env.runQuery(api.scrapeJobs.getRecentJobs, { limit });
+      const jobs = await c.env.runQuery(internal.scrapeJobs.getRecentJobs, { limit });
 
       return c.json(successResponse(jobs, {
         count: jobs.length,
@@ -697,7 +697,7 @@ app.get("/api/admin/scrape/:jobId",
     try {
       const jobId = c.req.param("jobId");
 
-      const job = await c.env.runQuery(api.scrapeJobs.getJobStatus, { jobId });
+      const job = await c.env.runQuery(internal.scrapeJobs.getJobStatus, { jobId });
 
       if (!job) {
         return c.json(errorResponse(

--- a/convex/scrapeJobs.ts
+++ b/convex/scrapeJobs.ts
@@ -3,7 +3,7 @@
  * Query and mutation functions for tracking scraping operations
  */
 
-import { mutation, query } from "./_generated/server";
+import { mutation, internalQuery } from "./_generated/server";
 import { v } from "convex/values";
 
 /**
@@ -44,8 +44,11 @@ export const upsertJob = mutation({
 
 /**
  * Get job status by ID
+ * internalQuery: only reached via the admin-key-gated /api/admin/scrape/:jobId
+ * HTTP route. A public query would be callable directly via the deployment URL,
+ * bypassing that gate.
  */
-export const getJobStatus = query({
+export const getJobStatus = internalQuery({
   args: { jobId: v.string() },
   handler: async (ctx, args) => {
     const job = await ctx.db
@@ -59,8 +62,10 @@ export const getJobStatus = query({
 
 /**
  * Get recent scrape jobs
+ * internalQuery: only reached via the admin-key-gated /api/admin/scrape/jobs
+ * HTTP route. See getJobStatus above.
  */
-export const getRecentJobs = query({
+export const getRecentJobs = internalQuery({
   args: { limit: v.optional(v.number()) },
   handler: async (ctx, args) => {
     const jobs = await ctx.db


### PR DESCRIPTION
## Problem

Three Convex functions were exported as public `query` functions and gated only by the `X-Admin-Key` check in the HTTP layer (`convex/http.ts`):

- `admin.getAdminStats`
- `scrapeJobs.getJobStatus`
- `scrapeJobs.getRecentJobs`

Because the Convex functions themselves were public, anyone holding the deployment's public URL (`NEXT_PUBLIC_CONVEX_URL`, which ships to the browser) could invoke them directly from a client and skip the admin-key gate entirely.

The most serious of these is `getAdminStats`: it returns **every API-key holder's email address** plus the full usage breakdown and top-users list. `getJobStatus` / `getRecentJobs` leak scrape-job operational metadata, a smaller exposure but the same class of bug.

## Fix

- Convert all three to `internalQuery` (imported from `./_generated/server`).
- Update `convex/http.ts` to call them via `internal.*` instead of `api.*`. The admin-key gate in the HTTP layer is unchanged and remains the sole entry point.
- `scrapeJobs.upsertJob` is intentionally left as a public `mutation`: the external scraper script writes job records through it via the deployment URL with no session auth.

## Verification

- `npx convex codegen` regenerates cleanly.
- `npx tsc --noEmit` exits 0.
- Confirmed no remaining `api.admin.getAdminStats` / `api.scrapeJobs.getJobStatus` / `api.scrapeJobs.getRecentJobs` references anywhere outside generated code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)