### PR TITLE
Bank permanent daily snapshots of usage counters

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,0 +1,20 @@
+/**
+ * Registered cron jobs.
+ *
+ * Convex only registers scheduled functions declared in the module named
+ * `crons` (this file). Each day this banks a permanent snapshot of the app's
+ * cumulative usage counters so any reporting window stays derivable forever.
+ */
+
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+crons.daily(
+  "daily metric snapshot",
+  { hourUTC: 8, minuteUTC: 10 },
+  internal.metricsRollup.snapshotDailyMetrics
+);
+
+export default crons;

--- a/convex/metricsRollup.ts
+++ b/convex/metricsRollup.ts
@@ -1,0 +1,90 @@
+/**
+ * Daily metric rollup.
+ *
+ * Banks a permanent snapshot of the app's cumulative usage counters once per
+ * UTC day so that any reporting window (7d / 30d / yearly) is derivable
+ * forever, independent of tables that prune or churn (e.g. requestLogs).
+ *
+ * The values snapshotted are the durable, monotonic counters:
+ *   - pageviewsTotal   cumulative site pageviews (pageviewCounters "total")
+ *   - uniquesToDate    sum of per-day unique-visitor counters (uvday:*)
+ *   - apiRequestsTotal cumulative API calls, summed across all apiKeys
+ *   - activeApiKeys    active API key count (point-in-time)
+ *   - apiKeysTotal     total API key count (point-in-time)
+ *
+ * apiRequestsTotal is stored raw (cumulative), not as a delta: differencing two
+ * snapshots gives per-day API volume, while the raw value stays reconstructable.
+ */
+
+import { internalMutation, internalQuery } from "./_generated/server";
+
+/** UTC "YYYY-MM-DD" for an epoch ms value. */
+const utcDay = (ms: number) => new Date(ms).toISOString().slice(0, 10);
+
+/**
+ * Internal: capture today's cumulative counters into metricSnapshots.
+ * Idempotent per UTC date - patches the existing row for the date if present,
+ * otherwise inserts a new one. Safe to run repeatedly within a day.
+ */
+export const snapshotDailyMetrics = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const date = utcDay(now);
+
+    // Cumulative site pageviews + sum of per-day unique-visitor counters.
+    const counters = await ctx.db.query("pageviewCounters").collect();
+    let pageviewsTotal = 0;
+    let uniquesToDate = 0;
+    for (const c of counters) {
+      if (c.key === "total") pageviewsTotal = c.count;
+      else if (c.key.startsWith("uvday:")) uniquesToDate += c.count;
+    }
+
+    // Cumulative API usage: requestCount is per-key lifetime cumulative, so the
+    // sum across keys is total API calls to date.
+    const keys = await ctx.db.query("apiKeys").collect();
+    let apiRequestsTotal = 0;
+    let activeApiKeys = 0;
+    for (const k of keys) {
+      apiRequestsTotal += k.requestCount || 0;
+      if (k.isActive) activeApiKeys++;
+    }
+
+    const metrics: Record<string, number> = {
+      pageviewsTotal,
+      uniquesToDate,
+      apiRequestsTotal,
+      activeApiKeys,
+      apiKeysTotal: keys.length,
+    };
+
+    const existing = await ctx.db
+      .query("metricSnapshots")
+      .withIndex("by_date", (q) => q.eq("date", date))
+      .first();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, { capturedAt: now, metrics });
+      return { date, updated: true, metrics };
+    }
+
+    await ctx.db.insert("metricSnapshots", { date, capturedAt: now, metrics });
+    return { date, updated: false, metrics };
+  },
+});
+
+/**
+ * Internal: the full snapshot series, ordered by date ascending.
+ * Windowed views (7d / 30d / yearly) are derived by the caller from this series.
+ */
+export const getMetricSnapshots = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    return await ctx.db
+      .query("metricSnapshots")
+      .withIndex("by_date")
+      .order("asc")
+      .collect();
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -368,4 +368,18 @@ export default defineSchema({
   })
     .index("by_status", ["status"])
     .index("by_status_and_createdAt", ["status", "createdAt"]),
+
+  /**
+   * Metric Snapshots - permanent daily banking of cumulative usage counters.
+   * One row per UTC date holds point-in-time values of the monotonic counters
+   * (total pageviews, cumulative API requests summed across all keys, etc.).
+   * Because the API-request total is stored raw (not as a delta), day-over-day
+   * differences yield per-day volume, and any window (7d/30d/yearly) stays
+   * derivable indefinitely without retaining raw request logs.
+   */
+  metricSnapshots: defineTable({
+    date: v.string(), // UTC "YYYY-MM-DD"
+    capturedAt: v.number(), // epoch ms when the snapshot was taken
+    metrics: v.record(v.string(), v.number()),
+  }).index("by_date", ["date"]),
 });


### PR DESCRIPTION
## What

Adds a durable daily rollup of the app's cumulative usage counters so any reporting window (7d / 30d / yearly) is derivable indefinitely.

- New `metricSnapshots` table: `{ date, capturedAt, metrics: record<string, number> }`, indexed `by_date`.
- New `convex/metricsRollup.ts`:
  - `snapshotDailyMetrics` (internalMutation): upserts one row per UTC date with the current cumulative counters. Idempotent (patches the day's row if it already exists).
  - `getMetricSnapshots` (internalQuery): returns the full series ordered by date ascending.
- New `convex/crons.ts` registering `daily("daily metric snapshot", 08:10 UTC, ...)`.

## Metrics captured per day

- `pageviewsTotal`: cumulative site pageviews (`pageviewCounters` "total").
- `uniquesToDate`: sum of per-day unique-visitor counters (`uvday:*`).
- `apiRequestsTotal`: cumulative API calls, summed across all `apiKeys.requestCount`.
- `activeApiKeys` / `apiKeysTotal`: active and total API key counts (point-in-time).

## Why

The API-request total is stored raw (cumulative), not as a delta. Differencing two snapshots yields per-day API volume going forward, while the underlying totals stay reconstructable even as churning tables like `requestLogs` are pruned. Backend-only and additive: no existing tables, functions, or crons are modified.

## Note on the crons file

Convex only registers scheduled functions from a module named `crons`. The repo's existing `convex/cron.ts` (singular) is not that module, so its jobs are not registered by Convex. This PR adds a correctly named `convex/crons.ts` for the new snapshot job and leaves `cron.ts` untouched. Consolidating or renaming `cron.ts` is intentionally out of scope here.

## Verification (dev deployment only)

- `npx convex dev --once`: pushed, added `metricSnapshots.by_date` index, typechecked clean.
- Ran `snapshotDailyMetrics` twice: first inserted a row, second patched the same row (one row per date), confirming idempotency.
- `getMetricSnapshots` returns the series.