### PR TITLE
Scrape the Free Agency roster page with current teams

### DIFF
--- a/scraper/config.js
+++ b/scraper/config.js
@@ -27,6 +27,22 @@ export const TEAM_TYPES = {
 };
 
 /**
+ * Roster pages that are not linked from the team-list pages but must be
+ * scraped alongside them. 2kratings parks offseason free agents on a
+ * standalone Free Agency page, so without this every free agent falls out
+ * of the dataset on the next scrape (and reconcile then prunes them).
+ */
+export const EXTRA_TEAMS = {
+  curr: [
+    {
+      link: '/teams/free-agency',
+      teamName: 'Free Agency',
+      teamImg: 'https://www.2kratings.com/wp-content/uploads/free-agency.svg'
+    }
+  ]
+};
+
+/**
  * DOM selectors for team roster pages
  */
 export const TEAM_SELECTORS = {

--- a/scraper/teamScraper.js
+++ b/scraper/teamScraper.js
@@ -3,7 +3,7 @@
  * Scrapes team listings and basic player data from team roster pages
  */
 
-import { BASE_URL, TEAM_SELECTORS, TEAM_TYPES, SCRAPER_OPTIONS } from './config.js';
+import { BASE_URL, TEAM_SELECTORS, TEAM_TYPES, EXTRA_TEAMS, SCRAPER_OPTIONS } from './config.js';
 import { normalizeUrl, logProgress, logError, delay, parseIntSafe, gotoThroughChallenge } from './utils.js';
 
 /**
@@ -83,8 +83,14 @@ export async function scrapeTeamLinks(page, teamType) {
     };
   });
 
-  logProgress(`Found ${uniqueTeams.length} teams`);
-  return uniqueTeams;
+  // Append roster pages that never appear on the team-list page (e.g. the
+  // Free Agency page), skipping any the list unexpectedly started including.
+  const extras = (EXTRA_TEAMS[teamType] || []).filter(
+    (extra) => !uniqueTeams.some((team) => team.link === extra.link)
+  );
+
+  logProgress(`Found ${uniqueTeams.length} teams (+${extras.length} extra)`);
+  return [...uniqueTeams, ...extras];
 }
 
 /**


### PR DESCRIPTION
## Problem

2kratings moves offseason free agents to a standalone Free Agency page (`/teams/free-agency`) that is not linked from `/current-teams`. The scraper only discovers teams from the list pages, so free agents vanished from the dataset on the next full scrape, and `reconcileRoster` then pruned their rows as departed. LeBron James, James Harden, DeMar DeRozan, and roughly 150 others currently have no `curr` entry in the API; `/bulk` returns none of them.

## Change

- `scraper/config.js`: new `EXTRA_TEAMS` map for roster pages that must be scraped alongside a team type but never appear on its list page. Contains the Free Agency page under `curr`.
- `scraper/teamScraper.js`: `scrapeTeamLinks` appends the extras (deduped by link in case the list page ever starts including them).

Free agents are stored with `team: "Free Agency"` and `teamType: "curr"`, so every existing endpoint (`/bulk`, `/batch`, search, filters) picks them up with no schema or API changes.

## Verification

Read-only scrape run against the live site: team discovery returns 31 entries (30 current teams + Free Agency), and the Free Agency roster yields 151 players through the existing selectors, including LeBron James (92 OVR, PF/SF). No data was written.

A targeted backfill (`node scripts/runScraper.js curr "Free Agency"`) is safe to run: reconcile is already skipped whenever a team filter is used, so a single-team run cannot prune the other current rosters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)