### PR TITLE
Cut database bandwidth: precompute cohort stats, cache SEO pages, revalidate on data change

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -101,3 +101,40 @@ jobs:
           bash scripts/scrape-retry.sh curr
           bash scripts/scrape-retry.sh class
           bash scripts/scrape-retry.sh allt
+
+      # cohortStats and teams are precomputed tables read by the site's
+      # dossier/team queries; rebuild them after every scrape so derived stats
+      # track the fresh player data. Runs only when the scrape steps succeeded
+      # (default step condition), so stats never rebuild over partial data.
+      - name: Rebuild derived stats tables
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: npx convex run cohorts:rebuildAll
+
+      # POST the run's actual diff (emitted by runScraper.js into
+      # scrape-diff.json) so the site re-renders only the pages that changed.
+      # Best-effort by design: an unreachable endpoint must never fail the
+      # scrape run; pages simply stay cached until the next successful scrape.
+      - name: Revalidate changed pages
+        env:
+          REVALIDATE_URL: ${{ secrets.REVALIDATE_URL }}
+          REVALIDATE_SECRET: ${{ secrets.REVALIDATE_SECRET }}
+        run: |
+          if [ ! -f scrape-diff.json ]; then
+            echo "No scrape diff file; skipping revalidation."
+            exit 0
+          fi
+          if [ -z "$REVALIDATE_URL" ] || [ -z "$REVALIDATE_SECRET" ]; then
+            echo "::warning::REVALIDATE_URL / REVALIDATE_SECRET not configured; skipping revalidation."
+            exit 0
+          fi
+          jq -c --arg secret "$REVALIDATE_SECRET" \
+            '{secret: $secret, players: (.players // []), teams: (.teams // []), deleted: (.deleted // [])}' \
+            scrape-diff.json > revalidate-body.json
+          if curl -sS --fail-with-body --max-time 60 -X POST "$REVALIDATE_URL/api/revalidate" \
+              -H 'Content-Type: application/json' --data @revalidate-body.json; then
+            echo "Revalidation request accepted."
+          else
+            echo "::warning::Revalidation request failed; cached pages refresh on the next successful scrape."
+          fi
+          rm -f revalidate-body.json

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -27,6 +27,12 @@ on:
         default: false
         type: boolean
 
+# Serialize runs: two overlapping scrapes would interleave their derived-table
+# rebuilds (cohortStats/teams) into inconsistent snapshots.
+concurrency:
+  group: scrape-nba2k
+  cancel-in-progress: false
+
 jobs:
   scrape:
     runs-on: ubuntu-latest
@@ -109,7 +115,15 @@ jobs:
       - name: Rebuild derived stats tables
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
-        run: npx convex run cohorts:rebuildAll
+          # Scheduled runs scrape curr only; rebuild only what was scraped so
+          # the weekly cron never re-reads the (larger) class/allt eras.
+          SCRAPED_TYPE: ${{ github.event.inputs.team_type || 'curr' }}
+        run: |
+          if [ "$SCRAPED_TYPE" = "all" ]; then
+            npx convex run cohorts:rebuildAll
+          else
+            npx convex run cohorts:rebuildAll "{\"teamType\": \"$SCRAPED_TYPE\"}"
+          fi
 
       # POST the run's actual diff (emitted by runScraper.js into
       # scrape-diff.json) so the site re-renders only the pages that changed.
@@ -131,10 +145,32 @@ jobs:
           jq -c --arg secret "$REVALIDATE_SECRET" \
             '{secret: $secret, players: (.players // []), teams: (.teams // []), deleted: (.deleted // [])}' \
             scrape-diff.json > revalidate-body.json
-          if curl -sS --fail-with-body --max-time 60 -X POST "$REVALIDATE_URL/api/revalidate" \
-              -H 'Content-Type: application/json' --data @revalidate-body.json; then
+          # A diff that never posts is permanently lost (unchanged players
+          # never re-enter a later diff), so retry before giving up, and on
+          # total failure preserve scrape-diff.json as an artifact for a
+          # manual re-post.
+          ok=0
+          for attempt in 1 2 3; do
+            if curl -sS --fail-with-body --max-time 60 -X POST "$REVALIDATE_URL/api/revalidate" \
+                -H 'Content-Type: application/json' --data @revalidate-body.json; then
+              ok=1
+              break
+            fi
+            echo "Revalidation attempt $attempt failed; retrying in $((attempt * 20))s."
+            sleep $((attempt * 20))
+          done
+          if [ "$ok" = "1" ]; then
             echo "Revalidation request accepted."
           else
-            echo "::warning::Revalidation request failed; cached pages refresh on the next successful scrape."
+            echo "::warning::Revalidation failed after 3 attempts; scrape-diff.json saved as artifact for manual re-post."
+            echo "REVALIDATE_FAILED=1" >> "$GITHUB_ENV"
           fi
           rm -f revalidate-body.json
+
+      - name: Preserve scrape diff after failed revalidation
+        if: env.REVALIDATE_FAILED == '1'
+        uses: actions/upload-artifact@v4
+        with:
+          name: scrape-diff
+          path: scrape-diff.json
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ node_modules/
 .env.local
 .env.*.local
 
+# Scrape pipeline output (per-run revalidation diff, CI-only)
+scrape-diff.json
+
 # Logs
 logs/
 *.log

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,68 @@
+import { timingSafeEqual } from "node:crypto";
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+
+/**
+ * On-demand cache invalidation for statically cached SEO pages.
+ *
+ * POST { secret, players?: string[], teams?: string[], deleted?: string[] }
+ * - secret: must match the REVALIDATE_SECRET env var (401 otherwise)
+ * - players: player slugs whose /players/[slug] pages changed
+ * - teams: team slugs whose /teams/[slug] pages changed
+ * - deleted: player slugs removed from the dataset; their pages are
+ *   revalidated too so the cached copy re-renders into a 404
+ *
+ * The scrape pipeline posts the diff of an ingest run here so only touched
+ * pages re-render; everything else stays served from the full route cache
+ * until the 30-day backstop.
+ */
+
+function slugList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (item): item is string => typeof item === "string" && /^[a-z0-9-]+$/.test(item)
+  );
+}
+
+export async function POST(request: Request) {
+  const secret = process.env.REVALIDATE_SECRET;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  const provided = typeof body.secret === "string" ? body.secret : "";
+  const expected = Buffer.from(secret ?? "");
+  const received = Buffer.from(provided);
+  const authorized =
+    !!secret && expected.length === received.length && timingSafeEqual(expected, received);
+  if (!authorized) {
+    return NextResponse.json({ error: "Invalid secret" }, { status: 401 });
+  }
+
+  const players = slugList(body.players);
+  const teams = slugList(body.teams);
+  const deleted = slugList(body.deleted);
+
+  const playerSlugs = [...new Set([...players, ...deleted])];
+  for (const slug of playerSlugs) {
+    revalidatePath(`/players/${slug}`);
+  }
+  const teamSlugs = [...new Set(teams)];
+  for (const slug of teamSlugs) {
+    revalidatePath(`/teams/${slug}`);
+  }
+  revalidatePath("/sitemap.xml");
+
+  return NextResponse.json({
+    revalidated: {
+      players: players.length,
+      teams: teamSlugs.length,
+      deleted: deleted.length,
+      paths: playerSlugs.length + teamSlugs.length + 1,
+    },
+  });
+}

--- a/app/players/[slug]/page.tsx
+++ b/app/players/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { preloadQuery, preloadedQueryResult } from "convex/nextjs";
@@ -5,24 +6,30 @@ import { api } from "@/convex/_generated/api";
 import { gameLabel, safeJsonLd, SITE_URL } from "@/lib/seo";
 import { PlayerDossierClient } from "./player-dossier-client";
 
-type TeamType = "curr" | "class" | "allt";
-type PageProps = {
-  params: Promise<{ slug: string }>;
-  searchParams: Promise<{ type?: string; team?: string }>;
-};
+// Canonical player pages are statically cached (full route cache) and
+// invalidated on demand via POST /api/revalidate after each scrape. The
+// 30-day revalidate is a backstop only. Era/team query variants (?type=,
+// ?team=) are resolved client-side so they never force dynamic rendering.
+export const revalidate = 2592000;
 
-function teamType(value?: string): TeamType | undefined {
-  return value === "curr" || value === "class" || value === "allt" ? value : undefined;
+// No paths at build time: every slug renders on first request, then is
+// cached. Unknown slugs still 404 via notFound() below.
+export async function generateStaticParams(): Promise<{ slug: string }[]> {
+  return [];
 }
 
-export async function generateMetadata({ params, searchParams }: PageProps): Promise<Metadata> {
-  const [{ slug }, search] = await Promise.all([params, searchParams]);
-  const preloaded = await preloadQuery(api.dossier.getDossier, {
-    slug,
-    teamType: teamType(search.type),
-    team: search.team,
-  });
-  const dossier = preloadedQueryResult(preloaded);
+type PageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+// One dossier fetch per render, shared by generateMetadata and the page body.
+const preloadDossier = cache((slug: string) =>
+  preloadQuery(api.dossier.getDossier, { slug })
+);
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const dossier = preloadedQueryResult(await preloadDossier(slug));
   if (!dossier) return { title: "Player not found", robots: { index: false, follow: false } };
 
   const p = dossier.player;
@@ -41,12 +48,8 @@ export async function generateMetadata({ params, searchParams }: PageProps): Pro
 }
 
 export default async function PlayerPage(props: PageProps) {
-  const [{ slug }, search] = await Promise.all([props.params, props.searchParams]);
-  const preloadedDossier = await preloadQuery(api.dossier.getDossier, {
-    slug,
-    teamType: teamType(search.type),
-    team: search.team,
-  });
+  const { slug } = await props.params;
+  const preloadedDossier = await preloadDossier(slug);
   const dossier = preloadedQueryResult(preloadedDossier);
   if (!dossier) notFound();
 

--- a/app/players/[slug]/page.tsx
+++ b/app/players/[slug]/page.tsx
@@ -10,6 +10,10 @@ import { PlayerDossierClient } from "./player-dossier-client";
 // invalidated on demand via POST /api/revalidate after each scrape. The
 // 30-day revalidate is a backstop only. Era/team query variants (?type=,
 // ?team=) are resolved client-side so they never force dynamic rendering.
+// force-static is required: convex/nextjs issues its fetches with
+// cache: "no-store", which would otherwise throw DYNAMIC_SERVER_USAGE
+// during on-demand static generation.
+export const dynamic = "force-static";
 export const revalidate = 2592000;
 
 // No paths at build time: every slug renders on first request, then is

--- a/app/players/[slug]/player-dossier-client.tsx
+++ b/app/players/[slug]/player-dossier-client.tsx
@@ -134,7 +134,14 @@ function PlayerDossier({
     api.dossier.getDossier,
     wantsVariant ? { slug, teamType: requestedType, team: teamParam ?? undefined } : "skip"
   );
-  const dossier = wantsVariant && variantDossier !== undefined ? variantDossier : canonicalDossier;
+  // While a requested variant loads, hold a quiet shell (undefined) rather
+  // than the canonical version: a Classic/All-Time deep link must never flash
+  // the current-era card before swapping.
+  const dossier = wantsVariant
+    ? variantDossier === undefined
+      ? undefined
+      : variantDossier
+    : canonicalDossier;
 
   useEffect(() => {
     setHasApiKey(!!localStorage.getItem(API_KEY_STORAGE_KEY));
@@ -294,6 +301,20 @@ function PlayerDossier({
         .map((c) => ({ label: CATEGORY_LABELS[c.key], pct: c.pct as number })),
     ];
   }, [dossier, player]);
+
+  if (dossier === undefined) {
+    return (
+      <div className="min-h-screen bg-[#faf9f5] font-body text-[#1a1918]">
+        <TopNav hasApiKey={hasApiKey} />
+        <div className="py-24 text-center">
+          <p className="m-0 font-plex text-[10.5px] tracking-[0.12em] text-[#8a8577]">
+            LOADING VERSION
+          </p>
+        </div>
+        <FooterStrip />
+      </div>
+    );
+  }
 
   if (dossier === null) {
     return (

--- a/app/players/[slug]/player-dossier-client.tsx
+++ b/app/players/[slug]/player-dossier-client.tsx
@@ -4,7 +4,7 @@ import { Suspense, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { usePreloadedQuery, type Preloaded } from "convex/react";
+import { usePreloadedQuery, useQuery, type Preloaded } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { TopNav } from "@/components/chrome/top-nav";
 import { FooterStrip } from "@/components/chrome/footer-strip";
@@ -120,7 +120,21 @@ function PlayerDossier({
 
   const [hasApiKey, setHasApiKey] = useState(false);
   const [endpointCopied, setEndpointCopied] = useState(false);
-  const dossier = usePreloadedQuery(preloadedDossier);
+
+  // The server renders (and statically caches) the canonical default version
+  // only. ?type= / ?team= variants are fetched here on the client and swap in
+  // over the canonical data once loaded, so query params never force dynamic
+  // rendering on the server.
+  const canonicalDossier = usePreloadedQuery(preloadedDossier);
+  const wantsVariant =
+    !!canonicalDossier &&
+    ((requestedType !== undefined && requestedType !== canonicalDossier.player.teamType) ||
+      (!!teamParam && teamParam !== canonicalDossier.player.team));
+  const variantDossier = useQuery(
+    api.dossier.getDossier,
+    wantsVariant ? { slug, teamType: requestedType, team: teamParam ?? undefined } : "skip"
+  );
+  const dossier = wantsVariant && variantDossier !== undefined ? variantDossier : canonicalDossier;
 
   useEffect(() => {
     setHasApiKey(!!localStorage.getItem(API_KEY_STORAGE_KEY));

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,8 +3,11 @@ import { fetchQuery } from "convex/nextjs";
 import { api } from "@/convex/_generated/api";
 import { SITE_URL, teamCanonical } from "@/lib/seo";
 
-// Refreshed on demand via POST /api/revalidate after each scrape; the 30-day
-// revalidate is a backstop only.
+// Rendered once and served from the full route cache: the Convex fetch is
+// uncached, so without force-static this route would re-run the entity
+// inventory query on every crawler request. Refreshed on demand via POST
+// /api/revalidate after each scrape; the 30-day revalidate is a backstop.
+export const dynamic = "force-static";
 export const revalidate = 2592000;
 
 const STATIC_ROUTES: Array<{

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,6 +3,10 @@ import { fetchQuery } from "convex/nextjs";
 import { api } from "@/convex/_generated/api";
 import { SITE_URL, teamCanonical } from "@/lib/seo";
 
+// Refreshed on demand via POST /api/revalidate after each scrape; the 30-day
+// revalidate is a backstop only.
+export const revalidate = 2592000;
+
 const STATIC_ROUTES: Array<{
   path: string;
   changeFrequency: "daily" | "weekly" | "monthly";

--- a/app/teams/[slug]/page.tsx
+++ b/app/teams/[slug]/page.tsx
@@ -10,6 +10,10 @@ import { TeamDetailClient } from "./team-detail-client";
 // invalidated on demand via POST /api/revalidate after each scrape. The
 // 30-day revalidate is a backstop only. ?type= era variants are resolved
 // client-side so they never force dynamic rendering.
+// force-static is required: convex/nextjs issues its fetches with
+// cache: "no-store", which would otherwise throw DYNAMIC_SERVER_USAGE
+// during on-demand static generation.
+export const dynamic = "force-static";
 export const revalidate = 2592000;
 
 // No paths at build time: every slug renders on first request, then is

--- a/app/teams/[slug]/page.tsx
+++ b/app/teams/[slug]/page.tsx
@@ -1,26 +1,49 @@
+import { cache } from "react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { fetchQuery, preloadQuery, preloadedQueryResult } from "convex/nextjs";
+import { preloadQuery, preloadedQueryResult } from "convex/nextjs";
 import { api } from "@/convex/_generated/api";
 import { ERA_LABELS, gameLabel, safeJsonLd, SITE_URL, teamCanonical } from "@/lib/seo";
 import { TeamDetailClient } from "./team-detail-client";
 
+// Canonical team pages are statically cached (full route cache) and
+// invalidated on demand via POST /api/revalidate after each scrape. The
+// 30-day revalidate is a backstop only. ?type= era variants are resolved
+// client-side so they never force dynamic rendering.
+export const revalidate = 2592000;
+
+// No paths at build time: every slug renders on first request, then is
+// cached. Unknown slugs still 404 via notFound() below.
+export async function generateStaticParams(): Promise<{ slug: string }[]> {
+  return [];
+}
+
 type TeamType = "curr" | "class" | "allt";
 type PageProps = {
   params: Promise<{ slug: string }>;
-  searchParams: Promise<{ type?: string }>;
 };
 
-function parseTeamType(value?: string): TeamType {
-  return value === "class" || value === "allt" ? value : "curr";
-}
+const ERAS: TeamType[] = ["curr", "class", "allt"];
 
-export async function generateMetadata({ params, searchParams }: PageProps): Promise<Metadata> {
-  const [{ slug }, search] = await Promise.all([params, searchParams]);
-  const era = parseTeamType(search.type);
-  const team = await fetchQuery(api.teams.getTeamBySlug, { slug, teamType: era });
+// Team slugs embed their era (classic slugs carry a season prefix, all-time
+// slugs an "all-time-" prefix), so a slug maps to exactly one era. Probe eras
+// in canonical order and keep the first hit. Cached so generateMetadata and
+// the page body share one lookup per render.
+const preloadTeam = cache(async (slug: string) => {
+  for (const era of ERAS) {
+    const preloaded = await preloadQuery(api.teams.getTeamBySlug, { slug, teamType: era });
+    if (preloadedQueryResult(preloaded) !== null) return preloaded;
+  }
+  return null;
+});
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const preloadedTeam = await preloadTeam(slug);
+  const team = preloadedTeam ? preloadedQueryResult(preloadedTeam) : null;
   if (!team) return { title: "Team not found", robots: { index: false, follow: false } };
 
+  const era = team.teamType;
   const game = gameLabel();
   const eraLabel = ERA_LABELS[era];
   const title = `${team.name} ${game} Roster, Ratings & Depth Chart`;
@@ -35,14 +58,14 @@ export async function generateMetadata({ params, searchParams }: PageProps): Pro
   };
 }
 
-export default async function TeamPage({ params, searchParams }: PageProps) {
-  const [{ slug }, search] = await Promise.all([params, searchParams]);
-  const era = parseTeamType(search.type);
-  const team = await fetchQuery(api.teams.getTeamBySlug, { slug, teamType: era });
-  if (!team) notFound();
+export default async function TeamPage({ params }: PageProps) {
+  const { slug } = await params;
+  const preloadedTeam = await preloadTeam(slug);
+  const team = preloadedTeam ? preloadedQueryResult(preloadedTeam) : null;
+  if (!preloadedTeam || !team) notFound();
 
-  const [preloadedTeam, preloadedRoster, preloadedBoard] = await Promise.all([
-    preloadQuery(api.teams.getTeamBySlug, { slug, teamType: era }),
+  const era = team.teamType;
+  const [preloadedRoster, preloadedBoard] = await Promise.all([
     preloadQuery(api.players.getPlayersByTeam, { team: team.name, teamType: era }),
     preloadQuery(api.teams.getBoard, { teamType: era }),
   ]);

--- a/app/teams/[slug]/team-detail-client.tsx
+++ b/app/teams/[slug]/team-detail-client.tsx
@@ -4,7 +4,7 @@ import { Suspense, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { usePreloadedQuery, type Preloaded } from "convex/react";
+import { usePreloadedQuery, useQuery, type Preloaded } from "convex/react";
 import { toast } from "sonner";
 import { api } from "@/convex/_generated/api";
 import { TopNav } from "@/components/chrome/top-nav";
@@ -147,14 +147,41 @@ function TeamPage({
   const router = useRouter();
   const slug = params.slug as string;
   const typeParam = searchParams.get("type");
-  const era: TeamType = typeParam === "class" || typeParam === "allt" ? typeParam : "curr";
+  const requestedEra: TeamType | null =
+    typeParam === "curr" || typeParam === "class" || typeParam === "allt" ? typeParam : null;
 
   const [view, setView] = useState<"depth" | "table">("depth");
   const [hasApiKey, setHasApiKey] = useState(false);
 
-  const teamInfo = usePreloadedQuery(preloadedTeam);
-  const roster = usePreloadedQuery(preloadedRoster) as RosterPlayer[];
-  const board = usePreloadedQuery(preloadedBoard);
+  // The server renders (and statically caches) the slug's own era, resolved
+  // from the slug alone. A ?type= that names a different era is fetched here
+  // on the client and swaps in once loaded, so query params never force
+  // dynamic rendering on the server.
+  const baseTeam = usePreloadedQuery(preloadedTeam);
+  const baseRoster = usePreloadedQuery(preloadedRoster) as RosterPlayer[];
+  const baseBoard = usePreloadedQuery(preloadedBoard);
+  const baseEra = (baseTeam?.teamType ?? "curr") as TeamType;
+  const wantsVariant = requestedEra !== null && baseTeam !== null && requestedEra !== baseEra;
+  const variantTeam = useQuery(
+    api.teams.getTeamBySlug,
+    wantsVariant ? { slug, teamType: requestedEra } : "skip"
+  );
+  const variantRoster = useQuery(
+    api.players.getPlayersByTeam,
+    wantsVariant && variantTeam ? { team: variantTeam.name, teamType: requestedEra } : "skip"
+  );
+  const variantBoard = useQuery(
+    api.teams.getBoard,
+    wantsVariant ? { teamType: requestedEra } : "skip"
+  );
+
+  // Until the variant resolves, keep rendering the base era so labels, links,
+  // and data stay consistent with each other.
+  const variantReady = wantsVariant && variantTeam !== undefined;
+  const teamInfo = variantReady ? variantTeam : baseTeam;
+  const roster = (variantReady ? variantRoster : baseRoster) as RosterPlayer[];
+  const board = variantReady ? variantBoard : baseBoard;
+  const era: TeamType = variantReady ? (requestedEra as TeamType) : baseEra;
 
   useEffect(() => {
     setHasApiKey(!!localStorage.getItem(API_KEY_STORAGE_KEY));

--- a/convex/attributeCategories.ts
+++ b/convex/attributeCategories.ts
@@ -3,6 +3,37 @@
  * Lives in convex/ so both Convex functions and app code can import it
  * (Convex functions cannot import from outside the convex directory).
  */
+/**
+ * Canonical category order. Percentile math and the precomputed
+ * cohortStats.roster[].catScores arrays both index categories by this order,
+ * so reordering this list invalidates stored cohortStats docs (rerun the
+ * cohorts:rebuildAll backfill after changing it).
+ */
+export const CATEGORY_KEYS = [
+  "outsideScoring",
+  "insideScoring",
+  "playmaking",
+  "athleticism",
+  "defending",
+  "rebounding",
+] as const;
+
+/**
+ * Mean of the attribute values present for the given keys, or null when none
+ * are present. Used both at request time (the viewed player's own scores) and
+ * at rebuild time (precomputed cohort arrays) - the two must stay the same
+ * function so stored and live category scores are bit-identical floats.
+ */
+export function categoryScore(
+  attrs: Record<string, number> | undefined,
+  keys: readonly string[]
+): number | null {
+  if (!attrs) return null;
+  const vals = keys.map((k) => attrs[k]).filter((n): n is number => typeof n === "number");
+  if (!vals.length) return null;
+  return vals.reduce((s, n) => s + n, 0) / vals.length;
+}
+
 export const ATTRIBUTE_CATEGORIES = {
   outsideScoring: [
     "closeShot",

--- a/convex/cohorts.ts
+++ b/convex/cohorts.ts
@@ -101,7 +101,17 @@ const cohortDocValidator = {
   ),
 };
 
-/** Upsert one cohortStats doc keyed by (teamType, primaryPosition). */
+/**
+ * Upsert one cohortStats doc keyed by (teamType, primaryPosition).
+ *
+ * Size ceiling: the null-position (whole era) doc is the largest (~300KB at
+ * ~770 players) and scales with era size against Convex's 1MB document limit.
+ * If replace() ever throws on size, the old doc persists (stale, not missing),
+ * so getDossier's missing-doc fallback will NOT fire; the signal is a failing
+ * rebuild step in CI. Mitigation when rosters approach the limit: split the
+ * per-attribute arrays across per-position docs and drop the era-wide doc's
+ * roster field.
+ */
 export const writeCohortStatsDoc = internalMutation({
   args: cohortDocValidator,
   handler: async (ctx, args) => {

--- a/convex/cohorts.ts
+++ b/convex/cohorts.ts
@@ -1,0 +1,345 @@
+/**
+ * Rebuild pipeline for the precomputed `cohortStats` and `teams` tables.
+ *
+ * These tables are derived views over `players`, refreshed after every scrape
+ * (see .github/workflows/scrape.yml) and runnable standalone as a backfill:
+ *
+ *   npx convex run cohorts:rebuildAll            # all eras
+ *   npx convex run cohorts:rebuildAll '{"teamType":"curr"}'
+ *
+ * The action paginates the players table (a whole era does not fit in one
+ * mutation transaction) and accumulates in action memory, then writes one
+ * small mutation per derived doc. All functions here are internal: the tables
+ * are rebuilt only by the scrape pipeline or an operator, never by clients.
+ *
+ * Parity contract with dossier.getDossier: value arrays are built from the
+ * same era-index document order the query's old era-scan used, sums are taken
+ * in that order BEFORE sorting (float sums are order-dependent), and rounding
+ * matches the query exactly. Violating any of these makes precomputed
+ * percentiles drift from the live-scan fallback path.
+ */
+
+import { internalAction, internalMutation, internalQuery } from "./_generated/server";
+import { internal } from "./_generated/api";
+import { v } from "convex/values";
+import { Id } from "./_generated/dataModel";
+import { ATTRIBUTE_CATEGORIES, CATEGORY_KEYS, categoryScore } from "./attributeCategories";
+
+const teamTypeValidator = v.union(v.literal("curr"), v.literal("class"), v.literal("allt"));
+type TeamType = "curr" | "class" | "allt";
+
+/** Team slug formula shared with teams.getBoard / sitemap URLs. */
+function teamSlug(teamName: string): string {
+  return teamName.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+}
+
+/** Slim player projection the rebuild needs (fat fields stay in the DB). */
+type SlimPlayer = {
+  _id: Id<"players">;
+  slug: string;
+  name: string;
+  team: string;
+  overall: number;
+  positions: string[] | null;
+  attributes: Record<string, number> | null;
+};
+
+/**
+ * One page of an era's players in by_teamType index order. Index order is
+ * load-bearing: cohort arrays and rosters must match the order the dossier
+ * fallback path sees from `.collect()` on the same index.
+ */
+export const playersPage = internalQuery({
+  args: {
+    teamType: teamTypeValidator,
+    paginationOpts: v.object({
+      numItems: v.number(),
+      cursor: v.union(v.string(), v.null()),
+    }),
+  },
+  handler: async (ctx, args) => {
+    const page = await ctx.db
+      .query("players")
+      .withIndex("by_teamType", (q) => q.eq("teamType", args.teamType))
+      .paginate(args.paginationOpts);
+    return {
+      isDone: page.isDone,
+      continueCursor: page.continueCursor,
+      page: page.page.map(
+        (p): SlimPlayer => ({
+          _id: p._id,
+          slug: p.slug,
+          name: p.name,
+          team: p.team,
+          overall: p.overall,
+          positions: p.positions ?? null,
+          attributes: p.attributes ?? null,
+        })
+      ),
+    };
+  },
+});
+
+const cohortDocValidator = {
+  teamType: teamTypeValidator,
+  primaryPosition: v.union(v.string(), v.null()),
+  attrs: v.record(v.string(), v.object({ values: v.array(v.number()), avg: v.number() })),
+  categories: v.record(
+    v.string(),
+    v.object({ values: v.array(v.number()), avg: v.union(v.number(), v.null()) })
+  ),
+  overall: v.object({ values: v.array(v.number()), avg: v.union(v.number(), v.null()) }),
+  roster: v.array(
+    v.object({
+      playerId: v.id("players"),
+      slug: v.string(),
+      name: v.string(),
+      team: v.string(),
+      overall: v.number(),
+      catScores: v.array(v.union(v.number(), v.null())),
+    })
+  ),
+};
+
+/** Upsert one cohortStats doc keyed by (teamType, primaryPosition). */
+export const writeCohortStatsDoc = internalMutation({
+  args: cohortDocValidator,
+  handler: async (ctx, args) => {
+    const doc = { ...args, updatedAt: new Date().toISOString() };
+    const existing = await ctx.db
+      .query("cohortStats")
+      .withIndex("by_teamType_and_position", (q) =>
+        q.eq("teamType", args.teamType).eq("primaryPosition", args.primaryPosition)
+      )
+      .first();
+    if (existing) {
+      await ctx.db.replace(existing._id, doc);
+      return { action: "replaced" as const };
+    }
+    await ctx.db.insert("cohortStats", doc);
+    return { action: "inserted" as const };
+  },
+});
+
+/**
+ * Drop cohortStats docs for positions that no longer exist in the era
+ * (e.g. a position group emptied out after a reconcile).
+ */
+export const pruneCohortStats = internalMutation({
+  args: {
+    teamType: teamTypeValidator,
+    keepPositions: v.array(v.union(v.string(), v.null())),
+  },
+  handler: async (ctx, args) => {
+    const keep = new Set(args.keepPositions);
+    const docs = await ctx.db
+      .query("cohortStats")
+      .withIndex("by_teamType_and_position", (q) => q.eq("teamType", args.teamType))
+      .collect();
+    let deleted = 0;
+    for (const doc of docs) {
+      if (!keep.has(doc.primaryPosition)) {
+        await ctx.db.delete(doc._id);
+        deleted++;
+      }
+    }
+    return { deleted };
+  },
+});
+
+/**
+ * Sync the `teams` table for one era to exactly the given (slug, name) set:
+ * upserts current teams, deletes departed ones.
+ */
+export const replaceTeamsForEra = internalMutation({
+  args: {
+    teamType: teamTypeValidator,
+    teams: v.array(v.object({ slug: v.string(), name: v.string() })),
+  },
+  handler: async (ctx, args) => {
+    const now = new Date().toISOString();
+    const existing = await ctx.db
+      .query("teams")
+      .withIndex("by_teamType", (q) => q.eq("teamType", args.teamType))
+      .collect();
+    const existingBySlug = new Map(existing.map((t) => [t.slug, t]));
+    const wantedSlugs = new Set(args.teams.map((t) => t.slug));
+
+    let inserted = 0;
+    let updated = 0;
+    let deleted = 0;
+    for (const team of args.teams) {
+      const current = existingBySlug.get(team.slug);
+      if (!current) {
+        await ctx.db.insert("teams", {
+          slug: team.slug,
+          teamType: args.teamType,
+          name: team.name,
+          updatedAt: now,
+        });
+        inserted++;
+      } else if (current.name !== team.name) {
+        await ctx.db.patch(current._id, { name: team.name, updatedAt: now });
+        updated++;
+      }
+    }
+    for (const doc of existing) {
+      if (!wantedSlugs.has(doc.slug)) {
+        await ctx.db.delete(doc._id);
+        deleted++;
+      }
+    }
+    return { inserted, updated, deleted };
+  },
+});
+
+/**
+ * Build one cohortStats doc from the cohort's players (already in era-index
+ * order). Averages replicate dossier.getDossier's exact rounding; sums run in
+ * cohort order before sorting so float results match the live-scan path.
+ */
+function buildCohortDoc(
+  cohort: SlimPlayer[],
+  teamType: TeamType,
+  primaryPosition: string | null
+) {
+  // Per-attribute sorted values + avg (avg rounded to 0.1 like the query)
+  const attrKeys = new Set<string>();
+  for (const p of cohort) {
+    if (p.attributes) for (const key of Object.keys(p.attributes)) attrKeys.add(key);
+  }
+  const attrs: Record<string, { values: number[]; avg: number }> = {};
+  for (const key of attrKeys) {
+    const values: number[] = [];
+    for (const p of cohort) {
+      const n = p.attributes?.[key];
+      if (typeof n === "number") values.push(n);
+    }
+    if (!values.length) continue;
+    const avg = Math.round((values.reduce((s, n) => s + n, 0) / values.length) * 10) / 10;
+    values.sort((a, b) => a - b);
+    attrs[key] = { values, avg };
+  }
+
+  // Per-category sorted score arrays + integer-rounded avg
+  const catScoresByPlayer = cohort.map((p) =>
+    CATEGORY_KEYS.map((cat) => categoryScore(p.attributes ?? undefined, ATTRIBUTE_CATEGORIES[cat]))
+  );
+  const categories: Record<string, { values: number[]; avg: number | null }> = {};
+  CATEGORY_KEYS.forEach((cat, i) => {
+    const values = catScoresByPlayer
+      .map((scores) => scores[i])
+      .filter((n): n is number => n !== null);
+    const avg =
+      values.length === 0
+        ? null
+        : Math.round(values.reduce((sum, n) => sum + n, 0) / values.length);
+    values.sort((a, b) => a - b);
+    categories[cat] = { values, avg };
+  });
+
+  // Overall sorted array + integer-rounded avg
+  const overallValues = cohort.map((p) => p.overall);
+  const overallAvg = overallValues.length
+    ? Math.round(overallValues.reduce((sum, n) => sum + n, 0) / overallValues.length)
+    : null;
+  const overall = { values: [...overallValues].sort((a, b) => a - b), avg: overallAvg };
+
+  // Compact roster in cohort order (similar-players candidates)
+  const roster = cohort.map((p, idx) => ({
+    playerId: p._id,
+    slug: p.slug,
+    name: p.name,
+    team: p.team,
+    overall: p.overall,
+    catScores: catScoresByPlayer[idx],
+  }));
+
+  return { teamType, primaryPosition, attrs, categories, overall, roster };
+}
+
+type EraRebuildSummary = {
+  teamType: TeamType;
+  players: number;
+  cohortDocs: number;
+  positions: string[];
+  teams: number;
+  teamsResult: { inserted: number; updated: number; deleted: number };
+};
+
+/**
+ * Rebuild cohortStats + teams from the players table. Pass teamType to limit
+ * to one era; omit it to rebuild all three.
+ */
+export const rebuildAll = internalAction({
+  args: { teamType: v.optional(teamTypeValidator) },
+  handler: async (ctx, args): Promise<EraRebuildSummary[]> => {
+    const eras: TeamType[] = args.teamType ? [args.teamType] : ["curr", "class", "allt"];
+    const summary: EraRebuildSummary[] = [];
+
+    for (const teamType of eras) {
+      // Collect the era in pages (whole eras exceed one transaction's limits)
+      const players: SlimPlayer[] = [];
+      let cursor: string | null = null;
+      for (;;) {
+        const res: {
+          isDone: boolean;
+          continueCursor: string;
+          page: SlimPlayer[];
+        } = await ctx.runQuery(internal.cohorts.playersPage, {
+          teamType,
+          paginationOpts: { numItems: 100, cursor },
+        });
+        players.push(...res.page);
+        if (res.isDone) break;
+        cursor = res.continueCursor;
+      }
+
+      // Position cohorts + the era-wide fallback cohort (primaryPosition null
+      // covers players without positions, whose cohort is the whole era)
+      const byPosition = new Map<string, SlimPlayer[]>();
+      for (const p of players) {
+        const pos = p.positions?.[0];
+        if (!pos) continue;
+        const group = byPosition.get(pos);
+        if (group) group.push(p);
+        else byPosition.set(pos, [p]);
+      }
+      const docs = [...byPosition.entries()].map(([pos, members]) =>
+        buildCohortDoc(members, teamType, pos)
+      );
+      docs.push(buildCohortDoc(players, teamType, null));
+
+      for (const doc of docs) {
+        await ctx.runMutation(internal.cohorts.writeCohortStatsDoc, doc);
+      }
+      await ctx.runMutation(internal.cohorts.pruneCohortStats, {
+        teamType,
+        keepPositions: docs.map((d) => d.primaryPosition),
+      });
+
+      // Teams table for the era
+      const teamsBySlug = new Map<string, string>();
+      for (const p of players) {
+        const slug = teamSlug(p.team);
+        if (!teamsBySlug.has(slug)) teamsBySlug.set(slug, p.team);
+      }
+      const teamsResult: EraRebuildSummary["teamsResult"] = await ctx.runMutation(internal.cohorts.replaceTeamsForEra, {
+        teamType,
+        teams: [...teamsBySlug.entries()].map(([slug, name]) => ({ slug, name })),
+      });
+
+      summary.push({
+        teamType,
+        players: players.length,
+        cohortDocs: docs.length,
+        positions: [...byPosition.keys()].sort(),
+        teams: teamsBySlug.size,
+        teamsResult,
+      });
+    }
+
+    console.log("[cohorts.rebuildAll]", JSON.stringify(summary));
+    return summary;
+  },
+});

--- a/convex/dossier.ts
+++ b/convex/dossier.ts
@@ -2,29 +2,17 @@
  * Player Dossier aggregate — everything the dossier page needs in one query:
  * the player, roster cycling neighbors, position-cohort percentiles, similar
  * players by attribute profile, rating history, and named badges.
+ *
+ * Cohort math reads ONE precomputed `cohortStats` doc (rebuilt at scrape time
+ * by cohorts.ts) instead of scanning every player doc in the era. When the
+ * doc is missing (fresh deploy before the backfill has run), the query falls
+ * back to the original era scan so pages never break on deploy ordering.
  */
 
-import { query } from "./_generated/server";
+import { query, QueryCtx } from "./_generated/server";
 import { v } from "convex/values";
-import { ATTRIBUTE_CATEGORIES } from "./attributeCategories";
-
-const CATEGORY_KEYS = [
-  "outsideScoring",
-  "insideScoring",
-  "playmaking",
-  "athleticism",
-  "defending",
-  "rebounding",
-] as const;
-
-type Attrs = Record<string, number> | undefined;
-
-function categoryScore(attrs: Attrs, keys: readonly string[]): number | null {
-  if (!attrs) return null;
-  const vals = keys.map((k) => attrs[k]).filter((n): n is number => typeof n === "number");
-  if (!vals.length) return null;
-  return vals.reduce((s, n) => s + n, 0) / vals.length;
-}
+import { Doc } from "./_generated/dataModel";
+import { ATTRIBUTE_CATEGORIES, CATEGORY_KEYS, categoryScore } from "./attributeCategories";
 
 /** Midpoint percentile (0-100) of value within values. */
 function percentile(values: number[], value: number): number {
@@ -36,6 +24,235 @@ function percentile(values: number[], value: number): number {
     else if (n === value) equal++;
   }
   return Math.round(((below + equal / 2) / values.length) * 100);
+}
+
+/** First index whose value is >= x in an ascending-sorted array. */
+function lowerBound(sorted: number[], x: number): number {
+  let lo = 0;
+  let hi = sorted.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (sorted[mid] < x) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/** First index whose value is > x in an ascending-sorted array. */
+function upperBound(sorted: number[], x: number): number {
+  let lo = 0;
+  let hi = sorted.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (sorted[mid] <= x) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/** Same midpoint percentile as percentile(), via binary search on a sorted array. */
+function percentileSorted(sorted: number[], value: number): number {
+  if (!sorted.length) return 50;
+  const below = lowerBound(sorted, value);
+  const equal = upperBound(sorted, value) - below;
+  return Math.round(((below + equal / 2) / sorted.length) * 100);
+}
+
+type CohortBlock = {
+  cohortSize: number;
+  attrStats: Record<string, { value: number; pct: number; avg: number }>;
+  categories: {
+    key: (typeof CATEGORY_KEYS)[number];
+    score: number | null;
+    avg: number | null;
+    pct: number | null;
+  }[];
+  overallPct: number;
+  overallAvg: number | null;
+  similar: {
+    name: string;
+    slug: string;
+    team: string;
+    teamType: "curr" | "class" | "allt";
+    positions: string[];
+    overall: number;
+    playerImage: string | null;
+  }[];
+};
+
+/** Cohort math from one precomputed cohortStats doc (the fast path). */
+async function cohortFromStats(
+  ctx: QueryCtx,
+  player: Doc<"players">,
+  stats: Doc<"cohortStats">
+): Promise<CohortBlock> {
+  // Per-attribute percentile + cohort average (matrix hover + signature stats)
+  const attrStats: Record<string, { value: number; pct: number; avg: number }> = {};
+  if (player.attributes) {
+    for (const [key, value] of Object.entries(player.attributes)) {
+      if (typeof value !== "number") continue;
+      const stat = stats.attrs[key];
+      if (!stat || !stat.values.length) continue;
+      attrStats[key] = {
+        value,
+        pct: percentileSorted(stat.values, value),
+        avg: stat.avg,
+      };
+    }
+  }
+
+  // Category scores + percentiles (radar + percentile bars)
+  const categories = CATEGORY_KEYS.map((cat) => {
+    const score = categoryScore(player.attributes, ATTRIBUTE_CATEGORIES[cat]);
+    const stat = stats.categories[cat];
+    return {
+      key: cat,
+      score: score === null ? null : Math.round(score),
+      avg: stat?.avg ?? null,
+      pct: score === null ? null : percentileSorted(stat?.values ?? [], score),
+    };
+  });
+  const overallAvg = stats.overall.avg;
+  const overallPct = percentileSorted(stats.overall.values, player.overall);
+
+  // Similar players: nearest by category-score profile within the cohort.
+  // Distance uses the precomputed catScores; display fields come from the
+  // live player docs (three point-reads) so images/positions never go stale.
+  const playerProfile = CATEGORY_KEYS.map((cat) =>
+    categoryScore(player.attributes, ATTRIBUTE_CATEGORIES[cat])
+  );
+  const nearest = stats.roster
+    .filter((entry) => entry.slug !== player.slug && entry.name !== player.name)
+    .map((entry) => {
+      let dist = 0;
+      let dims = 0;
+      entry.catScores.forEach((b, i) => {
+        const a = playerProfile[i];
+        if (a !== null && b !== null && b !== undefined) {
+          dist += (a - b) ** 2;
+          dims++;
+        }
+      });
+      dist += (player.overall - entry.overall) ** 2;
+      dims++;
+      return { entry, dist: dims ? dist / dims : Infinity };
+    })
+    .sort((a, b) => a.dist - b.dist)
+    .slice(0, 3);
+  const similarDocs = await Promise.all(nearest.map(({ entry }) => ctx.db.get(entry.playerId)));
+  const similar = similarDocs
+    .filter((p): p is Doc<"players"> => p !== null)
+    .map((p) => ({
+      name: p.name,
+      slug: p.slug,
+      team: p.team,
+      teamType: p.teamType,
+      positions: p.positions ?? [],
+      overall: p.overall,
+      playerImage: p.playerImage ?? null,
+    }));
+
+  return {
+    cohortSize: stats.overall.values.length,
+    attrStats,
+    categories,
+    overallPct,
+    overallAvg,
+    similar,
+  };
+}
+
+/**
+ * Original era-scan cohort math. Only runs when the cohortStats doc for the
+ * player's (teamType, primaryPosition) is missing, i.e. before the first
+ * cohorts:rebuildAll backfill on a deployment.
+ */
+async function cohortFromEraScan(
+  ctx: QueryCtx,
+  player: Doc<"players">,
+  primaryPosition: string | null
+): Promise<CohortBlock> {
+  const eraDocs = await ctx.db
+    .query("players")
+    .withIndex("by_teamType", (q) => q.eq("teamType", player.teamType))
+    .collect();
+  const cohort = primaryPosition
+    ? eraDocs.filter((p) => p.positions?.[0] === primaryPosition)
+    : eraDocs;
+
+  // Per-attribute percentile + cohort average (matrix hover + signature stats)
+  const attrStats: Record<string, { value: number; pct: number; avg: number }> = {};
+  if (player.attributes) {
+    for (const [key, value] of Object.entries(player.attributes)) {
+      if (typeof value !== "number") continue;
+      const values = cohort
+        .map((p) => p.attributes?.[key])
+        .filter((n): n is number => typeof n === "number");
+      if (!values.length) continue;
+      attrStats[key] = {
+        value,
+        pct: percentile(values, value),
+        avg: Math.round((values.reduce((s, n) => s + n, 0) / values.length) * 10) / 10,
+      };
+    }
+  }
+
+  // Category scores + percentiles (radar + percentile bars)
+  const categories = CATEGORY_KEYS.map((cat) => {
+    const keys = ATTRIBUTE_CATEGORIES[cat];
+    const score = categoryScore(player.attributes, keys);
+    const values = cohort
+      .map((p) => categoryScore(p.attributes, keys))
+      .filter((n): n is number => n !== null);
+    return {
+      key: cat,
+      score: score === null ? null : Math.round(score),
+      avg: values.length === 0 ? null : Math.round(values.reduce((sum, n) => sum + n, 0) / values.length),
+      pct: score === null ? null : percentile(values, score),
+    };
+  });
+  const overallAvg = cohort.length
+    ? Math.round(cohort.reduce((sum, p) => sum + p.overall, 0) / cohort.length)
+    : null;
+  const overallPct = percentile(
+    cohort.map((p) => p.overall),
+    player.overall
+  );
+
+  // Similar players: nearest by category-score profile within the cohort
+  const playerProfile = CATEGORY_KEYS.map((cat) =>
+    categoryScore(player.attributes, ATTRIBUTE_CATEGORIES[cat])
+  );
+  const similar = cohort
+    .filter((p) => p.slug !== player.slug && p.name !== player.name)
+    .map((p) => {
+      let dist = 0;
+      let dims = 0;
+      CATEGORY_KEYS.forEach((cat, i) => {
+        const a = playerProfile[i];
+        const b = categoryScore(p.attributes, ATTRIBUTE_CATEGORIES[cat]);
+        if (a !== null && b !== null) {
+          dist += (a - b) ** 2;
+          dims++;
+        }
+      });
+      dist += (player.overall - p.overall) ** 2;
+      dims++;
+      return { p, dist: dims ? dist / dims : Infinity };
+    })
+    .sort((a, b) => a.dist - b.dist)
+    .slice(0, 3)
+    .map(({ p }) => ({
+      name: p.name,
+      slug: p.slug,
+      team: p.team,
+      teamType: p.teamType,
+      positions: p.positions ?? [],
+      overall: p.overall,
+      playerImage: p.playerImage ?? null,
+    }));
+
+  return { cohortSize: cohort.length, attrStats, categories, overallPct, overallAvg, similar };
 }
 
 export const getDossier = query({
@@ -82,87 +299,17 @@ export const getDossier = query({
         positions: p.positions ?? [],
       }));
 
-    // Cohort: same era, same primary position
+    // Cohort: same era, same primary position (era-wide when no position)
     const primaryPosition = player.positions?.[0] ?? null;
-    const eraDocs = await ctx.db
-      .query("players")
-      .withIndex("by_teamType", (q) => q.eq("teamType", player.teamType))
-      .collect();
-    const cohort = primaryPosition
-      ? eraDocs.filter((p) => p.positions?.[0] === primaryPosition)
-      : eraDocs;
-
-    // Per-attribute percentile + cohort average (matrix hover + signature stats)
-    const attrStats: Record<string, { value: number; pct: number; avg: number }> = {};
-    if (player.attributes) {
-      for (const [key, value] of Object.entries(player.attributes)) {
-        if (typeof value !== "number") continue;
-        const values = cohort
-          .map((p) => p.attributes?.[key])
-          .filter((n): n is number => typeof n === "number");
-        if (!values.length) continue;
-        attrStats[key] = {
-          value,
-          pct: percentile(values, value),
-          avg: Math.round((values.reduce((s, n) => s + n, 0) / values.length) * 10) / 10,
-        };
-      }
-    }
-
-    // Category scores + percentiles (radar + percentile bars)
-    const categories = CATEGORY_KEYS.map((cat) => {
-      const keys = ATTRIBUTE_CATEGORIES[cat];
-      const score = categoryScore(player.attributes, keys);
-      const values = cohort
-        .map((p) => categoryScore(p.attributes, keys))
-        .filter((n): n is number => n !== null);
-      return {
-        key: cat,
-        score: score === null ? null : Math.round(score),
-        avg: values.length === 0 ? null : Math.round(values.reduce((sum, n) => sum + n, 0) / values.length),
-        pct: score === null ? null : percentile(values, score),
-      };
-    });
-    const overallAvg = cohort.length
-      ? Math.round(cohort.reduce((sum, p) => sum + p.overall, 0) / cohort.length)
-      : null;
-    const overallPct = percentile(
-      cohort.map((p) => p.overall),
-      player.overall
-    );
-
-    // Similar players: nearest by category-score profile within the cohort
-    const playerProfile = CATEGORY_KEYS.map((cat) =>
-      categoryScore(player.attributes, ATTRIBUTE_CATEGORIES[cat])
-    );
-    const similar = cohort
-      .filter((p) => p.slug !== player.slug && p.name !== player.name)
-      .map((p) => {
-        let dist = 0;
-        let dims = 0;
-        CATEGORY_KEYS.forEach((cat, i) => {
-          const a = playerProfile[i];
-          const b = categoryScore(p.attributes, ATTRIBUTE_CATEGORIES[cat]);
-          if (a !== null && b !== null) {
-            dist += (a - b) ** 2;
-            dims++;
-          }
-        });
-        dist += (player.overall - p.overall) ** 2;
-        dims++;
-        return { p, dist: dims ? dist / dims : Infinity };
-      })
-      .sort((a, b) => a.dist - b.dist)
-      .slice(0, 3)
-      .map(({ p }) => ({
-        name: p.name,
-        slug: p.slug,
-        team: p.team,
-        teamType: p.teamType,
-        positions: p.positions ?? [],
-        overall: p.overall,
-        playerImage: p.playerImage ?? null,
-      }));
+    const statsDoc = await ctx.db
+      .query("cohortStats")
+      .withIndex("by_teamType_and_position", (q) =>
+        q.eq("teamType", player.teamType).eq("primaryPosition", primaryPosition)
+      )
+      .first();
+    const { cohortSize, attrStats, categories, overallPct, overallAvg, similar } = statsDoc
+      ? await cohortFromStats(ctx, player, statsDoc)
+      : await cohortFromEraScan(ctx, player, primaryPosition);
 
     // In-season movement (milestones filled in over the season)
     const seasonMovement = player.seasonMovement ?? [];
@@ -225,7 +372,7 @@ export const getDossier = query({
         badgeCounts: player.badges ?? null,
       },
       primaryPosition,
-      cohortSize: cohort.length,
+      cohortSize,
       roster,
       attrStats,
       categories,

--- a/convex/players.ts
+++ b/convex/players.ts
@@ -302,6 +302,13 @@ export const reconcileRoster = mutation({
       aborted,
       reasons,
       sample,
+      // Slugs/teams actually removed this run, so the scrape pipeline can
+      // invalidate exactly those pages. Empty on dry runs and aborts (nothing
+      // was removed). Bounded by the 40% prune cap above.
+      deletedPlayers:
+        !aborted && !args.dryRun
+          ? orphans.map((o) => ({ slug: o.slug, team: o.team }))
+          : [],
     };
     console.log("[reconcileRoster]", JSON.stringify(result));
     return result;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -114,6 +114,64 @@ export default defineSchema({
     .index("by_team_and_type", ["team", "teamType"]),
 
   /**
+   * Cohort statistics - precomputed at scrape time (cohorts.ts rebuild) so the
+   * dossier query can compute percentiles/averages/similar-players from ONE
+   * document instead of scanning every player doc in the era.
+   *
+   * One doc per (teamType, primaryPosition) plus one per-era fallback doc with
+   * primaryPosition null covering the WHOLE era (the cohort used for players
+   * without positions). All value arrays are sorted ascending for binary
+   * search; averages are pre-rounded exactly as dossier.getDossier rounds them
+   * (attributes to 0.1, categories and overall to integers).
+   */
+  cohortStats: defineTable({
+    teamType: v.union(v.literal("curr"), v.literal("class"), v.literal("allt")),
+    primaryPosition: v.union(v.string(), v.null()),
+    // attribute key -> sorted cohort values + rounded average
+    attrs: v.record(
+      v.string(),
+      v.object({ values: v.array(v.number()), avg: v.number() })
+    ),
+    // category key (CATEGORY_KEYS) -> sorted cohort category scores + average
+    categories: v.record(
+      v.string(),
+      v.object({ values: v.array(v.number()), avg: v.union(v.number(), v.null()) })
+    ),
+    overall: v.object({
+      values: v.array(v.number()),
+      avg: v.union(v.number(), v.null()),
+    }),
+    // Compact cohort roster in era-index order (order matters: distance ties
+    // in similar-players resolve by stable sort over this order). catScores
+    // holds raw (unrounded) category scores in CATEGORY_KEYS order.
+    roster: v.array(
+      v.object({
+        playerId: v.id("players"),
+        slug: v.string(),
+        name: v.string(),
+        team: v.string(),
+        overall: v.number(),
+        catScores: v.array(v.union(v.number(), v.null())),
+      })
+    ),
+    updatedAt: v.string(), // ISO timestamp
+  }).index("by_teamType_and_position", ["teamType", "primaryPosition"]),
+
+  /**
+   * Teams - one doc per (slug, teamType), derived from player rows at scrape
+   * time (cohorts.ts rebuild). Gives teams.getTeamBySlug an indexed point-read
+   * instead of a players table scan.
+   */
+  teams: defineTable({
+    slug: v.string(), // team name lowercased, non-alphanumerics collapsed to "-"
+    teamType: v.union(v.literal("curr"), v.literal("class"), v.literal("allt")),
+    name: v.string(), // display name exactly as stored on player docs
+    updatedAt: v.string(), // ISO timestamp
+  })
+    .index("by_slug_and_type", ["slug", "teamType"])
+    .index("by_teamType", ["teamType"]),
+
+  /**
    * API Keys table - stores user API keys for authentication
    */
   apiKeys: defineTable({

--- a/convex/teams.ts
+++ b/convex/teams.ts
@@ -7,7 +7,13 @@ import { query } from "./_generated/server";
 import { v } from "convex/values";
 
 /**
- * Get team by slug - helper to convert slug to team name
+ * Get team by slug - helper to convert slug to team name.
+ *
+ * Point-read on the precomputed `teams` table (rebuilt at scrape time by
+ * cohorts.ts). While the table is still empty for an era (fresh deploy before
+ * the cohorts:rebuildAll backfill), falls back to deriving the team from
+ * player rows; once populated, a miss is authoritative and returns null
+ * without scanning players.
  */
 export const getTeamBySlug = query({
   args: {
@@ -15,10 +21,30 @@ export const getTeamBySlug = query({
     teamType: v.union(v.literal("curr"), v.literal("class"), v.literal("allt")),
   },
   handler: async (ctx, args) => {
-    // Get all players of this team type
+    const teamDoc = await ctx.db
+      .query("teams")
+      .withIndex("by_slug_and_type", (q) =>
+        q.eq("slug", args.slug).eq("teamType", args.teamType)
+      )
+      .first();
+    if (teamDoc) {
+      return {
+        name: teamDoc.name,
+        slug: args.slug,
+        teamType: args.teamType,
+      };
+    }
+
+    const eraPopulated = await ctx.db
+      .query("teams")
+      .withIndex("by_teamType", (q) => q.eq("teamType", args.teamType))
+      .first();
+    if (eraPopulated) return null;
+
+    // Fallback: era not backfilled yet; derive the team from player rows
     const players = await ctx.db
       .query("players")
-      .filter((q) => q.eq(q.field("teamType"), args.teamType))
+      .withIndex("by_teamType", (q) => q.eq("teamType", args.teamType))
       .collect();
 
     // Find a player whose team name matches the slug

--- a/scripts/runScraper.js
+++ b/scripts/runScraper.js
@@ -3,6 +3,7 @@
  * Runs the Playwright scraper and uploads results to Convex
  */
 
+import fs from "fs";
 import { ConvexHttpClient } from "convex/browser";
 import { api } from "../convex/_generated/api.js";
 import { CURRENT_GAME_VERSION } from "../convex/gameVersion.js";
@@ -14,6 +15,53 @@ import { initBrowser, createPage } from '../scraper/utils.js';
 // (NOT .convex.site which is for HTTP actions)
 const CONVEX_URL = process.env.CONVEX_URL || "https://canny-kingfisher-472.convex.cloud";
 const ADMIN_API_KEY = process.env.ADMIN_API_KEY;
+
+// Diff of what this run actually touched, for targeted page revalidation.
+// Merged (set-union) across runs/retry attempts into one JSON file
+// {players, teams, deleted} that the scrape workflow POSTs to the site's
+// /api/revalidate endpoint after a successful run.
+const SCRAPE_DIFF_FILE = process.env.SCRAPE_DIFF_FILE || "scrape-diff.json";
+
+/** Team slug formula shared with convex/teams.ts getBoard / sitemap URLs. */
+function teamSlug(teamName) {
+  return String(teamName || "").toLowerCase().replace(/[^a-z0-9]+/g, "-");
+}
+
+/**
+ * Merge this run's diff into SCRAPE_DIFF_FILE. Union semantics: a retry
+ * attempt after a partial (blocked) attempt sees already-updated players as
+ * "unchanged", so earlier attempts' slugs must survive. Never throws: diff
+ * emission is best-effort and must not fail a scrape.
+ */
+function mergeScrapeDiff({ players, teams, deleted }) {
+  try {
+    let existing = { players: [], teams: [], deleted: [] };
+    if (fs.existsSync(SCRAPE_DIFF_FILE)) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(SCRAPE_DIFF_FILE, "utf8"));
+        existing = {
+          players: Array.isArray(parsed.players) ? parsed.players : [],
+          teams: Array.isArray(parsed.teams) ? parsed.teams : [],
+          deleted: Array.isArray(parsed.deleted) ? parsed.deleted : [],
+        };
+      } catch {
+        // Corrupt file: start fresh rather than losing this run's diff.
+      }
+    }
+    const merged = {
+      players: [...new Set([...existing.players, ...players])].sort(),
+      teams: [...new Set([...existing.teams, ...teams])].sort(),
+      deleted: [...new Set([...existing.deleted, ...deleted])].sort(),
+    };
+    fs.writeFileSync(SCRAPE_DIFF_FILE, JSON.stringify(merged, null, 2) + "\n");
+    console.log(
+      `Scrape diff -> ${SCRAPE_DIFF_FILE}: ${merged.players.length} players, ` +
+      `${merged.teams.length} teams, ${merged.deleted.length} deleted`
+    );
+  } catch (error) {
+    console.error(`Failed to write scrape diff (non-fatal): ${error.message}`);
+  }
+}
 
 /**
  * Main scraper function
@@ -40,6 +88,11 @@ async function runScraper(options = {}) {
   let teamsScraped = 0;
   let emptyTeams = 0; // teams whose roster came back with 0 players (soft-block signal)
   const errors = [];
+
+  // Slugs this run actually touched (drives targeted page revalidation)
+  const changedPlayerSlugs = new Set(); // added + updated players
+  const deletedPlayerSlugs = new Set(); // removed by reconcile
+  const affectedTeamSlugs = new Set(); // teams of any player above
 
   console.log(`Starting scrape job ${jobId} for team type: ${teamType}`);
 
@@ -109,8 +162,12 @@ async function runScraper(options = {}) {
 
               if (result.action === 'inserted') {
                 playersAdded++;
+                changedPlayerSlugs.add(slug);
+                affectedTeamSlugs.add(teamSlug(fullPlayer.team || team.teamName));
               } else if (result.action === 'updated') {
                 playersUpdated++;
+                changedPlayerSlugs.add(slug);
+                affectedTeamSlugs.add(teamSlug(fullPlayer.team || team.teamName));
               } else {
                 playersUnchanged++;
               }
@@ -176,11 +233,21 @@ async function runScraper(options = {}) {
           dryRun: process.env.RECONCILE_DRY_RUN === 'true',
         });
         console.log(`Reconcile (${teamType}):`, JSON.stringify(reconcile));
+        for (const removed of reconcile.deletedPlayers ?? []) {
+          deletedPlayerSlugs.add(removed.slug);
+          affectedTeamSlugs.add(teamSlug(removed.team));
+        }
       } catch (error) {
         // Non-fatal: a reconcile failure shouldn't fail the scrape/upload.
         console.error(`Reconcile failed for ${teamType} (non-fatal):`, error.message);
       }
     }
+
+    mergeScrapeDiff({
+      players: [...changedPlayerSlugs],
+      teams: [...affectedTeamSlugs],
+      deleted: [...deletedPlayerSlugs],
+    });
 
     return {
       jobId,
@@ -203,6 +270,14 @@ async function runScraper(options = {}) {
     const duration = Date.now() - new Date(startTime).getTime();
 
     console.error(`Scrape job ${jobId} failed:`, error);
+
+    // Players upserted before the failure are real changes: record them so a
+    // later successful attempt's revalidation still covers their pages.
+    mergeScrapeDiff({
+      players: [...changedPlayerSlugs],
+      teams: [...affectedTeamSlugs],
+      deleted: [...deletedPlayerSlugs],
+    });
 
     return {
       jobId,


### PR DESCRIPTION
## Problem

Player and team pages rendered dynamically on every request, and each render read far more than it returned:

- `dossier.getDossier` collected every full player document in an era per call to compute cohort percentiles, averages, and similar players.
- `app/players/[slug]/page.tsx` ran that query twice per request (generateMetadata and the page body). Team pages ran `getTeamBySlug` three times.
- `teams.getTeamBySlug` scanned the entire players table with an unindexed filter to resolve a display name.
- `sitemap.ts` re-queried the full entity inventory on every crawler hit.

Under crawler plus organic traffic this produced roughly 12 GB/day of database reads.

## Change

**Convex**
- New `cohortStats` table (per era and primary position, plus a per-era whole-cohort doc): sorted attribute/category/overall distributions, averages, and a compact roster for similar-players. New `teams` lookup table. Both rebuilt by internal, batched mutations wired into the scrape pipeline and runnable standalone.
- `getDossier` now reads the player's versions, one roster, and one stats doc; percentiles via binary search. `getTeamBySlug` is an indexed point read. Both fall back to the previous implementation when the derived doc is missing, so deploy order cannot break pages. Response shapes unchanged.

**Next.js**
- Canonical player/team pages and the sitemap are statically cached (30-day backstop). Query-string era/team variants hydrate client-side; the server render no longer touches searchParams. Landmine documented in code: `convex/nextjs` fetches are no-store, so these routes require `dynamic = "force-static"`.
- New secret-protected `POST /api/revalidate` accepting `{secret, players[], teams[], deleted[]}`; the scrape workflow posts its actual diff (with retries, preserving the diff as an artifact if all attempts fail), so pages re-render only when their data actually changed. Scheduled scrapes rebuild only the scraped era's derived tables, and runs are serialized under a concurrency group.

## Behavior changes
- Bare classic/all-time team URLs (e.g. `/teams/2015-16-golden-state-warriors`) now render the team instead of returning 404; canonicals are unchanged.
- Era/team deep links show a brief loading state instead of flashing the default version.

## Deploy notes
1. Deploy Convex to prod first (additive, fallback-safe), then run `npx convex run cohorts:rebuildAll --prod`.
2. Set `REVALIDATE_SECRET` on the Vercel project and `REVALIDATE_URL`/`REVALIDATE_SECRET` as Actions secrets (until set, the revalidate step skips non-fatally and pages ride the 30-day backstop).
3. Merge; verify per-call read size collapses on the dashboard and dispatch one scrape to prove the revalidation chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)